### PR TITLE
✨ Feat: 메시지 박스 컴포넌트 추가

### DIFF
--- a/src/components/common/MessageBox/MessageBox.stories.ts
+++ b/src/components/common/MessageBox/MessageBox.stories.ts
@@ -12,5 +12,5 @@ export default meta;
 type Story = StoryObj<typeof MessageBox>;
 
 export const Default: Story = {
-  args: { direction: 'right' },
+  args: { direction: 'right', text: '세미콜론 쓰기' },
 };

--- a/src/components/common/MessageBox/MessageBox.stories.ts
+++ b/src/components/common/MessageBox/MessageBox.stories.ts
@@ -1,0 +1,16 @@
+import { Meta, StoryObj } from '@storybook/react';
+import MessageBox from './MessageBox';
+
+const meta: Meta<typeof MessageBox> = {
+  title: 'Components/Common/MessageBox',
+  component: MessageBox,
+  tags: ['autodocs'],
+  argTypes: {},
+};
+
+export default meta;
+type Story = StoryObj<typeof MessageBox>;
+
+export const Default: Story = {
+  args: { direction: 'right' },
+};

--- a/src/components/common/MessageBox/MessageBox.tsx
+++ b/src/components/common/MessageBox/MessageBox.tsx
@@ -35,21 +35,21 @@ const MessageWrapper = styled.div<{ direction: 'left' | 'right' }>`
     border-color: rgba(255, 255, 255, 0);
     border-width: 10px;
     margin-top: -10px;
-    ${(props) =>
-      props.direction === 'left' && `left: 100%; border-left-color: white;`}
-    ${(props) =>
-      props.direction === 'right' && `right: 100%; border-right-color: white;`}
+    ${({ direction }) =>
+      direction === 'right' && `left: 100%; border-left-color: white;`}
+    ${({ direction }) =>
+      direction === 'left' && `right: 100%; border-right-color: white;`}
   }
 
   &:before {
     border-color: rgba(0, 0, 0, 0);
     border-width: 13px;
     margin-top: -13px;
-    ${(props) =>
-      props.direction === 'left' &&
+    ${({ direction }) =>
+      direction === 'right' &&
       `left: 100%; border-left-color: ${colors.grey[300]}`}
-    ${(props) =>
-      props.direction === 'right' &&
+    ${({ direction }) =>
+      direction === 'left' &&
       `right: 100%; border-right-color: ${colors.grey[300]}`}
   }
 `;

--- a/src/components/common/MessageBox/MessageBox.tsx
+++ b/src/components/common/MessageBox/MessageBox.tsx
@@ -1,0 +1,67 @@
+import { Flex } from '@chakra-ui/react';
+import styled from '@emotion/styled';
+import colors from '~/theme/colors';
+
+interface MessageBoxProps {
+  text: string;
+  direction?: 'left' | 'right';
+}
+
+const MessageWrapper = styled.div<{ direction: 'left' | 'right' }>`
+  position: relative;
+  background: white;
+  border: 2px solid ${colors.grey[300]};
+  border-radius: 10px;
+  min-height: 5rem;
+  min-width: 10rem;
+  max-width: 70%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 10px;
+
+  &:after,
+  &:before {
+    top: 50%;
+    border: solid transparent;
+    content: '';
+    height: 0;
+    width: 0;
+    position: absolute;
+    pointer-events: none;
+  }
+
+  &:after {
+    border-color: rgba(255, 255, 255, 0);
+    border-width: 10px;
+    margin-top: -10px;
+    ${(props) =>
+      props.direction === 'left' && `left: 100%; border-left-color: white;`}
+    ${(props) =>
+      props.direction === 'right' && `right: 100%; border-right-color: white;`}
+  }
+
+  &:before {
+    border-color: rgba(0, 0, 0, 0);
+    border-width: 13px;
+    margin-top: -13px;
+    ${(props) =>
+      props.direction === 'left' &&
+      `left: 100%; border-left-color: ${colors.grey[300]}`}
+    ${(props) =>
+      props.direction === 'right' &&
+      `right: 100%; border-right-color: ${colors.grey[300]}`}
+  }
+`;
+
+const MessageBox = ({ text, direction = 'left' }: MessageBoxProps) => {
+  return (
+    <Flex>
+      <MessageWrapper direction={direction}>
+        <div>{text}</div>
+      </MessageWrapper>
+    </Flex>
+  );
+};
+
+export default MessageBox;

--- a/src/components/common/MessageBox/index.ts
+++ b/src/components/common/MessageBox/index.ts
@@ -1,0 +1,1 @@
+export { default as MessageBox } from './MessageBox';

--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -1,2 +1,3 @@
 export * from './DotTag';
 export * from './CustomAvatar';
+export * from './MessageBox';


### PR DESCRIPTION
# 🔨 개발 사항 

메시지 박스 컴포넌트를 개발했습니다.
![image](https://github.com/Lovely-4K/love-frontend/assets/32586926/fff34455-21f1-439a-978e-db37d033e301)


### 개발 스크린 샷
<!-- 리뷰어들이 개발 & 변경 사항을 파악하기 쉽도록 스크린 샷을 첨부해주면 좋아요 -->

![image](https://github.com/Lovely-4K/love-frontend/assets/32586926/12aa5daf-a4bd-4bbf-a6d4-894f6f0d9282)


# 📝 리뷰어들이 보면 좋을 사항
[차크라의 popover](https://v1.chakra-ui.com/docs/components/overlay/popover) 를 적용하려 했었는데 해당 UI는 버튼 등 트리거가 필요해서 캘린더 색상 지정, 지도 마커 클릭시 info창은 popover를 사용하면 될 것 같고 '질문' 기능에서 사용되는 text를 감싸는 말풍선 메세지는 이와 별도로 구분해야할 것 같습니다. (현재 구현한 기능은 질문 쪽에서 사용되는 말풍선 area 입니다!)



# 🚨 이슈번호
- close #6 
