### PR TITLE
✨ Feat: Input 컴포넌트 구현

### DIFF
--- a/src/components/common/CustomInput/CustomInput.stories.ts
+++ b/src/components/common/CustomInput/CustomInput.stories.ts
@@ -1,0 +1,29 @@
+import { Meta, StoryObj } from '@storybook/react';
+import CustomInput from './CustomInput';
+
+const meta: Meta<typeof CustomInput> = {
+  title: 'Components/Common/CustomInput',
+  component: CustomInput,
+  tags: ['autodocs'],
+  argTypes: {
+    size: {
+      control: { type: 'radio' },
+      options: ['medium', 'large'],
+    },
+    type: {
+      control: { type: 'radio' },
+      options: ['outline', 'flushed', 'noneStyle'],
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof CustomInput>;
+
+export const Default: Story = {
+  args: {
+    size: 'large',
+    placehodler: 'input 컴포넌트 테스트',
+    type: 'outline',
+  },
+};

--- a/src/components/common/CustomInput/CustomInput.stories.ts
+++ b/src/components/common/CustomInput/CustomInput.stories.ts
@@ -23,7 +23,7 @@ type Story = StoryObj<typeof CustomInput>;
 export const Default: Story = {
   args: {
     size: 'large',
-    placehodler: 'input 컴포넌트 테스트',
+    placeholder: 'input 컴포넌트 테스트',
     type: 'outline',
   },
 };

--- a/src/components/common/CustomInput/CustomInput.tsx
+++ b/src/components/common/CustomInput/CustomInput.tsx
@@ -15,14 +15,14 @@ const sizes = {
 };
 
 const CustomInput = ({
-  placehodler,
+  placeholder,
   type = 'outline',
   size = 'medium',
   borderColor = '#eee',
-}) => {
+}: CustomInputProps) => {
   return (
     <Input
-      placeholder={placehodler}
+      placeholder={placeholder}
       variant={type}
       size={sizes[size]}
       borderColor={borderColor}

--- a/src/components/common/CustomInput/CustomInput.tsx
+++ b/src/components/common/CustomInput/CustomInput.tsx
@@ -1,8 +1,10 @@
 import { Input } from '@chakra-ui/react';
 
+// todo: hover & active 처리하기
+
 interface CustomInputProps {
   placeholder: string;
-  type: 'outline' | 'flushed' | 'noneStyle';
+  type?: 'outline' | 'flushed' | 'noneStyle';
   size?: 'medium' | 'large';
   borderColor?: string;
 }
@@ -14,7 +16,7 @@ const sizes = {
 
 const CustomInput = ({
   placehodler,
-  type,
+  type = 'outline',
   size = 'medium',
   borderColor = '#eee',
 }) => {
@@ -23,7 +25,7 @@ const CustomInput = ({
       placeholder={placehodler}
       variant={type}
       size={sizes[size]}
-      borderColor={borderColor && '#eee'}
+      borderColor={borderColor}
     ></Input>
   );
 };

--- a/src/components/common/CustomInput/CustomInput.tsx
+++ b/src/components/common/CustomInput/CustomInput.tsx
@@ -1,0 +1,31 @@
+import { Input } from '@chakra-ui/react';
+
+interface CustomInputProps {
+  placeholder: string;
+  type: 'outline' | 'flushed' | 'noneStyle';
+  size?: 'medium' | 'large';
+  borderColor?: string;
+}
+
+const sizes = {
+  medium: 'md',
+  large: 'lg',
+};
+
+const CustomInput = ({
+  placehodler,
+  type,
+  size = 'medium',
+  borderColor = '#eee',
+}) => {
+  return (
+    <Input
+      placeholder={placehodler}
+      variant={type}
+      size={sizes[size]}
+      borderColor={borderColor && '#eee'}
+    ></Input>
+  );
+};
+
+export default CustomInput;

--- a/src/components/common/CustomInput/index.ts
+++ b/src/components/common/CustomInput/index.ts
@@ -1,0 +1,1 @@
+export { default as CustomInput } from './CustomInput';


### PR DESCRIPTION
# 🔨 개발 사항 | 변경 사항

Input 컴포넌트를 구현했습니다.

<img width="800" alt="image" src="https://github.com/Lovely-4K/love-frontend/assets/80307321/4f7d150d-631a-401d-


# 📝 리뷰어들이 보면 좋을 사항

- type

Fill 을 제외한 모든 Input 을 받을 수 있습니다.

<img width="799" alt="image" src="https://github.com/Lovely-4K/love-frontend/assets/80307321/ff4042b4-45bf-4b88-9882-0db407fd5cb8">

- 사이즈

Input 의 width 는 현재 지원하지 않는 상태입니다. 상위 컴포넌트에서 조정할 수 없는 경우 추가하도록 하겠습니다.


# 🚨 이슈번호

- close #15