### PR TITLE
✨ Feat: Carousel 컴포넌트 추가

### DIFF
--- a/src/components/domain/Carousel/Carousel.stories.ts
+++ b/src/components/domain/Carousel/Carousel.stories.ts
@@ -1,0 +1,22 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import Carousel from './Carousel';
+
+const meta: Meta<typeof Carousel> = {
+  title: 'Components/Domain/Carousel',
+  component: Carousel,
+
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof Carousel>;
+
+export const Default: Story = {
+  args: {
+    pictures: [
+      'https://cdn.britannica.com/39/7139-050-A88818BB/Himalayan-chocolate-point.jpg',
+      'https://upload.wikimedia.org/wikipedia/commons/1/15/Cat_August_2010-4.jpg',
+      'https://www.alleycat.org/wp-content/uploads/2019/03/FELV-cat.jpg',
+    ],
+  },
+};

--- a/src/components/domain/Carousel/Carousel.tsx
+++ b/src/components/domain/Carousel/Carousel.tsx
@@ -1,0 +1,57 @@
+import { memo, useRef, useState } from 'react';
+
+interface CarouselProps {
+  pictures: string[];
+}
+
+const Carousel = memo(({ pictures }: CarouselProps) => {
+  const carouselRef = useRef<HTMLDivElement>(null);
+  const [activeIndex, setActiveIndex] = useState(0);
+
+  const handleScroll = () => {
+    if (carouselRef.current === null) return;
+
+    const index = Math.round(
+      carouselRef.current.scrollLeft / carouselRef.current.clientWidth,
+    );
+    setActiveIndex(index);
+  };
+
+  const handleButtonClick = (index: number) => {
+    if (carouselRef.current === null) return;
+
+    carouselRef.current.scrollTo({
+      left: index * carouselRef.current.clientWidth,
+      behavior: 'smooth',
+    });
+  };
+
+  return (
+    <div className="relative">
+      <div
+        ref={carouselRef}
+        className="carousel w-full rounded-[0.625rem]"
+        onScroll={handleScroll}
+      >
+        {pictures.map((picture, index) => (
+          <div key={index} id={`item${index}`} className="carousel-item w-full">
+            <img src={picture} className="w-full" />
+          </div>
+        ))}
+      </div>
+      <div className="absolute bottom-5 left-1/2 flex w-full -translate-x-1/2 justify-center gap-1 py-2">
+        {pictures.map((_, index) => (
+          <button
+            key={index}
+            onClick={() => handleButtonClick(index)}
+            className={`h-3 w-3 rounded-full ${
+              index === activeIndex ? 'bg-black' : 'bg-gray-500'
+            }`}
+          />
+        ))}
+      </div>
+    </div>
+  );
+});
+
+export default Carousel;

--- a/src/components/domain/Carousel/Carousel.tsx
+++ b/src/components/domain/Carousel/Carousel.tsx
@@ -11,9 +11,9 @@ const Carousel = memo(({ pictures }: CarouselProps) => {
   const handleScroll = () => {
     if (carouselRef.current === null) return;
 
-    const index = Math.round(
-      carouselRef.current.scrollLeft / carouselRef.current.clientWidth,
-    );
+    const { scrollLeft, clientWidth } = carouselRef.current;
+
+    const index = Math.round(scrollLeft / clientWidth);
     setActiveIndex(index);
   };
 

--- a/src/components/domain/Carousel/index.ts
+++ b/src/components/domain/Carousel/index.ts
@@ -1,0 +1,1 @@
+export { default as Carousel } from './Carousel';

--- a/src/components/domain/index.ts
+++ b/src/components/domain/index.ts
@@ -1,0 +1,1 @@
+export * from './Carousel';


### PR DESCRIPTION
# 🔨 개발 사항 | 변경 사항
<!-- 무엇을 개발했는지, 변경사항이 있다면 무엇인지 알려주세요! -->
Carousel 컴포넌트를 추가했습니다.

### 개발 사항
<!-- 커밋 단위로 잘게 나누어서 작성합시다! 개발사항1, 개발사항2... 등등 -->

<img width="649" alt="스크린샷 2023-10-24 오전 12 38 05" src="https://github.com/Lovely-4K/love-frontend/assets/45515388/e621073a-9e8e-4113-aa68-8b7ca712ae59">

daisyUI에서는 Carousel 하단 버튼의 작동이 url에 #을 추가해서 작동하는 방식이였는데 이를 사용하지 않고 다른 방식으로 구현했습니다.

https://github.com/Lovely-4K/love-frontend/assets/45515388/c649b3ab-83f1-4091-99ba-781dc7146ff4

스크롤이나 버튼으로 이동 시 현재 페이지에 맞는 버튼이 active 상태로 변경되게 적용했습니다.

# 🚨 이슈번호
- close #21 
