### PR TITLE
✨ Feat: 평점 컴포넌트 추가

### DIFF
--- a/src/components/domain/Rating/Rating.stories.ts
+++ b/src/components/domain/Rating/Rating.stories.ts
@@ -1,0 +1,14 @@
+import { Meta, StoryObj } from '@storybook/react';
+import Rating from './Rating';
+
+const meta: Meta<typeof Rating> = {
+  title: 'Components/Common/Rating',
+  component: Rating,
+  tags: ['autodocs'],
+  argTypes: {},
+};
+
+export default meta;
+type Story = StoryObj<typeof Rating>;
+
+export const Default: Story = {};

--- a/src/components/domain/Rating/Rating.tsx
+++ b/src/components/domain/Rating/Rating.tsx
@@ -1,0 +1,33 @@
+const Rating = () => {
+  return (
+    <div className="rating gap-1">
+      <input
+        type="radio"
+        name="rating-3"
+        className="mask mask-heart bg-base-primary"
+      />
+      <input
+        type="radio"
+        name="rating-3"
+        className="mask mask-heart bg-base-primary"
+      />
+      <input
+        type="radio"
+        name="rating-3"
+        className="mask mask-heart bg-base-primary"
+      />
+      <input
+        type="radio"
+        name="rating-3"
+        className="mask mask-heart bg-base-primary"
+      />
+      <input
+        type="radio"
+        name="rating-3"
+        className="mask mask-heart bg-base-primary"
+      />
+    </div>
+  );
+};
+
+export default Rating;

--- a/src/components/domain/Rating/index.ts
+++ b/src/components/domain/Rating/index.ts
@@ -1,0 +1,1 @@
+export { default as Rating } from './Rating';

--- a/src/components/domain/index.ts
+++ b/src/components/domain/index.ts
@@ -1,1 +1,2 @@
 export * from './Carousel';
+export * from './Rating';


### PR DESCRIPTION
# 🔨 개발 사항 

다이어리 등에 사용되는 평점 컴포넌트

### 개발 사항

daisy ui의 raiting 컴포넌트를 가져와 색상을 커스텀했습니다.


### 개발 스크린 샷
<img width="349" alt="image" src="https://github.com/Lovely-4K/love-frontend/assets/32586926/1ee5cab8-7699-481b-9861-fa6d24eba0aa">


# 📝 리뷰어들이 보면 좋을 사항

daisy ui의 rating 컴포넌트 코드가 길어서 묶어서 색상만 적용해둔 상태입니다. 
백엔드쪽에 평점 값 (1,2,3,4,5) 등을 보내기 위해서 추가 로직이 필요할텐데 이 부분은 개발을 진행하면서 입맛에 맞게 커스텀하면 좋을 것 같습니다.

# 🚨 이슈번호

- close #4 
