### PR TITLE
✨ Feat: input 컴포넌트 타입 추가

### DIFF
--- a/src/theme/input.ts
+++ b/src/theme/input.ts
@@ -1,0 +1,12 @@
+const input = {
+  '.input-bottom': {
+    'border-radius': '0',
+    'border-top-width': '0',
+    'border-left-width': '0',
+    'border-right-width': '0',
+    'border-bottom-width': '1px',
+    'border-bottom-style': 'solid',
+  },
+};
+
+export default input;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,7 +1,8 @@
-import colors from './src/theme/colors';
-import btn from './src/theme/btn';
 import daisyui from 'daisyui';
 import theme from 'daisyui/src/theming/themes';
+import btn from './src/theme/btn';
+import colors from './src/theme/colors';
+import input from './src/theme/input';
 
 /** @type {import('tailwindcss').Config} */
 export default {
@@ -16,6 +17,7 @@ export default {
       {
         light: {
           ...btn,
+          ...input,
           ...theme['[data-theme=light]'],
         },
       },


### PR DESCRIPTION
# 🔨 개발 사항 | 변경 사항

daisy UI 에서 지원하지 않는 Input-bottom 에 대한 스타일을 tailwind config 파일에 추가했습니다.

### 컴포넌트 구조 

`src/theme/input` 파일 속에 작성했습니다.

# 📝 리뷰어들이 보면 좋을 사항

- input-bordered
- input-bottom
- input-ghost

클래스 이름을 사용하여 input 컴포넌트를 각각 사용할 수 있습니다.

# 🚨 이슈번호

- close #20 
