### PR TITLE
✨ Feature: QuestionCreate 페이지 API 함수 구현 & 카카오 지도 불러오기 구현

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,5 +15,9 @@
   <body>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
+    <script
+      type="text/javascript"
+      src="//dapi.kakao.com/v2/maps/sdk.js?appkey=e047e874a0ead765d233c2ba0a20f17b&libraries=services,clusterer"
+    ></script>
   </body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "axios": "^1.5.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-kakao-maps-sdk": "^1.1.24",
         "react-router-dom": "^6.17.0"
       },
       "devDependencies": {
@@ -43,6 +44,7 @@
         "eslint-plugin-react-hooks": "^4.6.0",
         "eslint-plugin-react-refresh": "^0.4.3",
         "eslint-plugin-storybook": "^0.6.15",
+        "kakao.maps.d.ts": "^0.1.39",
         "netlify-cli": "^16.9.3",
         "postcss": "^8.4.31",
         "prettier": "^3.0.3",
@@ -2052,7 +2054,6 @@
       "version": "7.23.2",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.2.tgz",
       "integrity": "sha512-mM8eg4yl5D6i3lu2QKPuPH4FArvJ8KhTofbE7jwMUv9KX5mBvwPAqnV3MlyBNqdp9RyRKP6Yck8TrfYrPvX3bg==",
-      "dev": true,
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
       },
@@ -12766,6 +12767,11 @@
       "engines": {
         "node": ">=4.0"
       }
+    },
+    "node_modules/kakao.maps.d.ts": {
+      "version": "0.1.39",
+      "resolved": "https://registry.npmjs.org/kakao.maps.d.ts/-/kakao.maps.d.ts-0.1.39.tgz",
+      "integrity": "sha512-KXENJ8hHYtjb5G+0vf8TXx/PwWW4j5ndDiQTSMvGtF7EFWu2P3N/+Zivcj9/UKn3j29Iz/sIUaA7WL8Ug3IDGQ=="
     },
     "node_modules/keyv": {
       "version": "4.5.4",
@@ -32556,6 +32562,19 @@
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true
     },
+    "node_modules/react-kakao-maps-sdk": {
+      "version": "1.1.24",
+      "resolved": "https://registry.npmjs.org/react-kakao-maps-sdk/-/react-kakao-maps-sdk-1.1.24.tgz",
+      "integrity": "sha512-leLbFwBj6zbTdDg6A9U7EwYT2oq0+2F+NHZSVTyCmmvyc4yt2zpRvUmcAt8I6h2SDUdgHbpvKAV1sZoRIxD4JQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.22.15",
+        "kakao.maps.d.ts": "^0.1.39"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17 || ^18",
+        "react-dom": "^16.8 || ^17 || ^18"
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.0.tgz",
@@ -32848,8 +32867,7 @@
     "node_modules/regenerator-runtime": {
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz",
-      "integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA==",
-      "dev": true
+      "integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA=="
     },
     "node_modules/regenerator-transform": {
       "version": "0.15.2",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "axios": "^1.5.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-kakao-maps-sdk": "^1.1.24",
     "react-router-dom": "^6.17.0"
   },
   "devDependencies": {
@@ -47,6 +48,7 @@
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-react-refresh": "^0.4.3",
     "eslint-plugin-storybook": "^0.6.15",
+    "kakao.maps.d.ts": "^0.1.39",
     "netlify-cli": "^16.9.3",
     "postcss": "^8.4.31",
     "prettier": "^3.0.3",

--- a/src/components/common/CategoryButton/CategoryButton.tsx
+++ b/src/components/common/CategoryButton/CategoryButton.tsx
@@ -3,7 +3,7 @@ import { CircleButton } from '..';
 import CategoryIcon from './CategoryIcon';
 import categoryType from './CategoryTypes';
 
-interface CategoryButtonProps extends HtmlHTMLAttributes<HTMLButtonElement> {
+interface CategoryButtonProps extends HtmlHTMLAttributes<HTMLDivElement> {
   type: categoryType;
   active: boolean;
 }
@@ -20,9 +20,9 @@ const CategoryButton = ({ type, active, onClick }: CategoryButtonProps) => {
   const icon = CategoryIcon({ type });
 
   return (
-    <button onClick={onClick}>
+    <div onClick={onClick}>
       <CircleButton active={active} icon={icon} label={titles[type]} />
-    </button>
+    </div>
   );
 };
 

--- a/src/components/domain/Footer/Footer.tsx
+++ b/src/components/domain/Footer/Footer.tsx
@@ -10,18 +10,16 @@ import {
 } from '~/assets/icons';
 
 const Footer = () => {
+  const { MAIN, DIARY, CALENDAR, QUESTION, SETTING } = paths;
+
   return (
     <div className="fixed z-40 flex h-24 w-screen flex-col-reverse lg:h-screen lg:w-28 lg:flex-row">
       <div className="flex items-center justify-around bg-base-white lg:flex-col lg:justify-start lg:gap-3 lg:p-3">
-        <FooterItem url={paths.MAIN} svg={IconHome} label={'홈'} />
-        <FooterItem url={paths.CALENDAR} svg={IconDiary} label={'다이어리'} />
-        <FooterItem url={paths.CALENDAR} svg={IconCalendar} label={'캘린더'} />
-        <FooterItem
-          url={paths.CALENDAR}
-          svg={IconQuestion}
-          label={'질문하기'}
-        />
-        <FooterItem url={paths.CALENDAR} svg={IconSetting} label={'환경설정'} />
+        <FooterItem url={MAIN} svg={IconHome} label={'홈'} />
+        <FooterItem url={DIARY} svg={IconDiary} label={'다이어리'} />
+        <FooterItem url={CALENDAR} svg={IconCalendar} label={'캘린더'} />
+        <FooterItem url={QUESTION} svg={IconQuestion} label={'질문하기'} />
+        <FooterItem url={SETTING} svg={IconSetting} label={'환경설정'} />
       </div>
       <TemperatureBar percent={100} />
     </div>

--- a/src/pages/Diary/Diary.tsx
+++ b/src/pages/Diary/Diary.tsx
@@ -2,10 +2,9 @@ import { DiarySideBar } from '~/pages/Diary/components/DiaryCommon';
 
 const Diary = () => {
   return (
-    <>
-      <DiarySideBar></DiarySideBar>
-      <div>hi</div>
-    </>
+    <div className="h-full w-full">
+      <DiarySideBar />
+    </div>
   );
 };
 

--- a/src/pages/Diary/Diary.tsx
+++ b/src/pages/Diary/Diary.tsx
@@ -1,9 +1,30 @@
+import { Map } from 'react-kakao-maps-sdk';
+import { useKakaoLoader as useKakaoLoaderOrigin } from 'react-kakao-maps-sdk';
 import { DiarySideBar } from '~/pages/Diary/components/DiaryCommon';
 
 const Diary = () => {
+  useKakaoLoaderOrigin({
+    appkey: 'e047e874a0ead765d233c2ba0a20f17b',
+    libraries: ['clusterer', 'drawing', 'services'],
+  });
+
   return (
     <div className="h-full w-full">
       <DiarySideBar />
+      <Map // 지도를 표시할 Container
+        id="map"
+        center={{
+          // 지도의 중심좌표
+          lat: 33.450701,
+          lng: 126.570667,
+        }}
+        style={{
+          // 지도의 크기
+          width: '100%',
+          height: '350px',
+        }}
+        level={3} // 지도의 확대 레벨
+      />
     </div>
   );
 };

--- a/src/pages/Diary/components/DiaryCommon/DiaryCategoryList.tsx
+++ b/src/pages/Diary/components/DiaryCommon/DiaryCategoryList.tsx
@@ -4,7 +4,7 @@ const DiaryCategoryList = () => {
   return (
     <div className="flex flex-col gap-4">
       <span className="font-large font-bold text-base-black">카테고리</span>
-      <CategoryList></CategoryList>
+      <CategoryList />
     </div>
   );
 };

--- a/src/pages/Diary/components/DiaryCommon/DiaryHeader.tsx
+++ b/src/pages/Diary/components/DiaryCommon/DiaryHeader.tsx
@@ -2,14 +2,12 @@ import { IconTopArrow } from '~/assets/icons';
 
 const DiaryHeader = () => {
   return (
-    <>
-      <div className="font-title flex gap-2 font-bold">
-        <button className="text-grey-300">
-          <IconTopArrow className="h-4 w-4 -rotate-90 fill-grey-300" />
-        </button>
-        <span>김선익 내과</span>
-      </div>
-    </>
+    <div className="font-title flex gap-2 font-bold">
+      <button className="text-grey-300">
+        <IconTopArrow className="h-4 w-4 -rotate-90 fill-grey-300" />
+      </button>
+      <span>김선익 내과</span>
+    </div>
   );
 };
 

--- a/src/pages/Diary/components/DiaryContent/DiaryContent.tsx
+++ b/src/pages/Diary/components/DiaryContent/DiaryContent.tsx
@@ -25,12 +25,10 @@ const DiaryContent = () => {
 
   const HeaderButton = () =>
     editMode || (
-      <>
-        <div className="font-small flex gap-2 text-grey-400">
-          <button onClick={handleEditMode}>수정</button>
-          <button>삭제</button>
-        </div>
-      </>
+      <div className="font-small flex gap-2 text-grey-400">
+        <button onClick={handleEditMode}>수정</button>
+        <button>삭제</button>
+      </div>
     );
 
   const EditButton = () =>
@@ -52,27 +50,25 @@ const DiaryContent = () => {
     );
 
   return (
-    <>
-      <div className="flex w-full max-w-[20rem] flex-col gap-6 overflow-y-auto overflow-x-hidden">
-        <div className="flex items-center justify-between">
-          <DiaryHeader />
-          <HeaderButton />
-        </div>
-        <div className="flex items-center justify-between">
-          <DiaryContentDate editMode={editMode} />
-          <DiaryContentRating editMode={editMode} />
-        </div>
-        <DiaryCategoryList />
-        <div className="flex flex-col gap-2">
-          <span className="font-large font-bold text-base-black">
-            다이어리 내용
-          </span>
-          <DiaryContentImgs editMode={editMode} />
-          <DiaryContentText editMode={editMode} />
-        </div>
-        <EditButton />
+    <div className="flex w-full max-w-[20rem] flex-col gap-6 overflow-y-auto overflow-x-hidden">
+      <div className="flex items-center justify-between">
+        <DiaryHeader />
+        <HeaderButton />
       </div>
-    </>
+      <div className="flex items-center justify-between">
+        <DiaryContentDate editMode={editMode} />
+        <DiaryContentRating editMode={editMode} />
+      </div>
+      <DiaryCategoryList />
+      <div className="flex flex-col gap-2">
+        <span className="font-large font-bold text-base-black">
+          다이어리 내용
+        </span>
+        <DiaryContentImgs editMode={editMode} />
+        <DiaryContentText editMode={editMode} />
+      </div>
+      <EditButton />
+    </div>
   );
 };
 

--- a/src/pages/Diary/components/DiaryContent/DiaryContentRating.tsx
+++ b/src/pages/Diary/components/DiaryContent/DiaryContentRating.tsx
@@ -6,14 +6,12 @@ interface DiaryContentRatingProps {
 
 const DiaryContentRating = ({ editMode }: DiaryContentRatingProps) => {
   return (
-    <>
-      <div className="flex flex-col gap-2">
-        <span className="font-large font-bold text-base-black">평점</span>
-        <div>
-          <Rating readonly={!editMode} />
-        </div>
+    <div className="flex flex-col gap-2">
+      <span className="font-large font-bold text-base-black">평점</span>
+      <div>
+        <Rating readonly={!editMode} />
       </div>
-    </>
+    </div>
   );
 };
 

--- a/src/pages/QuestionCreate/components/QuestionCreateForm/Form.tsx
+++ b/src/pages/QuestionCreate/components/QuestionCreateForm/Form.tsx
@@ -2,7 +2,7 @@ import FormAnswer from './FormAnswer';
 import FormQuestion from './FormQuestion';
 import useQuestionCreateForm from '~/pages/QuestionCreate/hooks/useQuestionCreateForm';
 
-/** @todo- answer, question 에 대한 상태관리를 여기서 해주어야 함 */
+/** @todo- data === undefined 일 시, 로딩 기능 추가, isError 일 시 Toast UI 추가 */
 const Form = () => {
   const { question, answers, handleSubmitForm } = useQuestionCreateForm();
   const buttonInvalidate = question.length === 0 || answers.length === 0;

--- a/src/pages/QuestionCreate/components/QuestionCreateHeader.tsx
+++ b/src/pages/QuestionCreate/components/QuestionCreateHeader.tsx
@@ -1,10 +1,13 @@
+import { paths } from '~/router';
 import { NavigationHeader } from '~/components/domain';
 
 const QuestionCreateHeader = () => {
+  const { QUESTION } = paths;
+
   return (
     <div className="mx-[-3rem]">
       <NavigationHeader
-        prevPageLink={'/question'}
+        prevPageLink={QUESTION}
         pageTitle="우리만의 질문 작성"
       />
     </div>

--- a/src/pages/QuestionCreate/hooks/useCreateForm.ts
+++ b/src/pages/QuestionCreate/hooks/useCreateForm.ts
@@ -1,0 +1,37 @@
+import { useMutation } from '@tanstack/react-query';
+
+import axios from 'axios';
+import type { Question, code, links } from '~/types';
+
+interface QuestionResponse {
+  body?: Question;
+  code: code;
+  links?: links;
+}
+
+interface createFormParams {
+  questionForm: Question;
+}
+
+const useCreateForm = () => {
+  const createForm = async ({ questionForm }: createFormParams) => {
+    const subURL = 'questions/question-forms?';
+    const params = `memberId=${1}&coupleId=${1}`;
+    const URL = subURL + params;
+    const response = await axios.post<QuestionResponse>(URL, {
+      data: questionForm,
+    });
+
+    return response.data;
+  };
+
+  const { mutateAsync, data, isError } = useMutation({
+    mutationFn: async (createFormParams: createFormParams) => {
+      return createForm(createFormParams);
+    },
+  });
+
+  return { mutateAsync, data, isError };
+};
+
+export default useCreateForm;

--- a/src/pages/QuestionCreate/hooks/useQuestionCreateForm.tsx
+++ b/src/pages/QuestionCreate/hooks/useQuestionCreateForm.tsx
@@ -1,18 +1,35 @@
 import React, { useContext } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { paths } from '~/router';
 import { QuestionCreateFormContext } from '../contexts/QuestionCreateFormContext';
+import useCreateForm from './useCreateForm';
 
 const useQuestionCreateForm = () => {
+  const navigate = useNavigate();
+  const { mutateAsync, data, isError } = useCreateForm();
   const { question, setQuestion, answers, setAnswers } = useContext(
     QuestionCreateFormContext,
   );
 
-  /** @todo-백엔드 API 연결 로직 추가해야 함 */
-  const handleSubmitForm = (
+  const handleSubmitForm = async (
     event:
       | React.FormEvent<HTMLFormElement>
       | React.MouseEvent<HTMLButtonElement>,
   ) => {
     event.preventDefault();
+    const data = await mutateAsync({
+      questionForm: {
+        questionContent: question,
+        firstChoice: answers[0],
+        secondChoice: answers[1],
+        thirdChoice: answers[2],
+        fourthChoice: answers[3],
+      },
+    });
+
+    if (data) {
+      navigate(paths.QUESTION);
+    }
   };
 
   const handleQuestionChange = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -46,6 +63,8 @@ const useQuestionCreateForm = () => {
   };
 
   return {
+    data,
+    isError,
     question,
     answers,
     handleSubmitForm,

--- a/src/pages/QuestionHistory/components/HistoryHeader.tsx
+++ b/src/pages/QuestionHistory/components/HistoryHeader.tsx
@@ -1,9 +1,13 @@
+import { paths } from '~/router';
+
 import { NavigationHeader } from '~/components/domain';
 
 const HistoryHeader = () => {
+  const { QUESTION } = paths;
+
   return (
     <div className="mx-[-3rem]">
-      <NavigationHeader pageTitle="우리의 질문들" prevPageLink="/question" />
+      <NavigationHeader pageTitle="우리의 질문들" prevPageLink={QUESTION} />
     </div>
   );
 };

--- a/src/router/paths.ts
+++ b/src/router/paths.ts
@@ -6,6 +6,7 @@ const PATHS = {
   QUESTION_HISTORY: '/question/history',
   QUESTION_CREATE: '/question/create',
   DIARY: '/diary',
+  SETTING: '/setting',
 };
 
 export default PATHS;

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -1,0 +1,14 @@
+interface code {
+  code: 200 | 201 | 204 | 400 | 401 | 403 | 500;
+}
+
+interface links {
+  links: link[];
+}
+
+interface link {
+  rel: string;
+  href: string;
+}
+
+export type { code, links };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,2 +1,3 @@
 export type * from './question';
 export type * from './member';
+export type * from './common';

--- a/src/types/question.ts
+++ b/src/types/question.ts
@@ -1,10 +1,10 @@
 interface Question {
-  questionId: number;
+  questionId?: number;
   questionContent: string;
   firstChoice: string;
   secondChoice: string;
-  thirdChoice: string | null;
-  fourthChoice: string | null;
+  thirdChoice?: string;
+  fourthChoice?: string;
 }
 
 interface QuestionHistoryDetail {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,6 +21,8 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
 
+    "types": ["kakao.maps.d.ts"],
+
     "baseUrl": "./src",
     "paths": {
       "~/*": ["*"]


### PR DESCRIPTION
# 🔨 개발 사항 | 변경 사항

### 질문 생성 (QuestionCreate) 페이지 react-query 함수 구현

- `useCreateForm` 커스텀 훅을 작성하였습니다. 
- `useMutation` 함수를 사용하여 질문 요청을 생성합니다.
- 반환값으로 `mutate` 대신 `mutateAsync` 를 사용하여 요청이 성공할 시 질문 페이지 (Question) 로 이동하도록 했습니다.

```tsx
    const data = await mutateAsync({
      questionForm: {
        questionContent: question,
        firstChoice: answers[0],
        secondChoice: answers[1],
        thirdChoice: answers[2],
        fourthChoice: answers[3],
      },
    });

    if (data) {
      navigate(paths.QUESTION);
    }
```


### 카카오 지도 불러오기 구현

`react-kakao-maps-sdk` 라이브러리를 사용하여 카카오 지도 API 를 연결 & 지도를 불러왔습니다.

### 개발 스크린 샷
<img width="1440" alt="Untitled" src="https://github.com/Lovely-4K/love-frontend/assets/80307321/312adcff-a8c0-415b-b390-2ae3a44305ee">


# 📝 리뷰어들이 보면 좋을 사항

### react-query 훅에 대하여
- 컴포넌트 Context 분리 훅인 `useQuestionCreateForm` 과 react-query 훅인 `useCreateForm` 이 이름이 유사합니다. 좋은 네이밍을 고민해보고 추후 수정하겠습니다.
- 현재 사용자가 생성한 answers 를 일일이 명령형으로 프로퍼티를 추가해주고 있는데 선언형 방식으로 바꾸는 방법을 생각해보겠습니다.

### 지도 API 에 대하여
- 공통 `Hooks` 폴더에 `useKakaoLoader` 훅을 추가했습니다. 해당 훅을 `Diary` 폴더 속에서만 쓰는 훅으로 변경해야할까요?


# 🚨 이슈번호

- close #75 
