### PR TITLE
🚨 Fix: 질문 페이지 API 연동 수정

### DIFF
--- a/src/pages/Question/components/QuestionChat/QuestionChat.tsx
+++ b/src/pages/Question/components/QuestionChat/QuestionChat.tsx
@@ -4,25 +4,32 @@ import useGetQuestionDetail from '~/pages/QuestionHistory/hooks/useGetQuestionDe
 
 const QuestionChat = () => {
   const { data: question } = useGetQuestion();
-  const { data: { boyAnswer, girlAnswer } = {} } = useGetQuestionDetail(
+  const { data: questionDetail } = useGetQuestionDetail(
     question?.body?.questionId || -1,
   );
 
-  console.log(boyAnswer, girlAnswer);
+  const {
+    myAnswer = '',
+    opponentAnswer = '',
+    myProfile = '',
+    opponentProfile = '',
+  } = questionDetail || {};
 
   return (
     <div className="mt-16">
       <QuestionChatItem
         type={'start'}
-        answerStatus={!!boyAnswer}
+        answerStatus={!!myAnswer}
         author={'나의 답변'}
-        message={boyAnswer}
+        picture={myProfile}
+        message={myAnswer}
       />
       <QuestionChatItem
         type={'end'}
-        answerStatus={!!girlAnswer}
+        answerStatus={!!opponentAnswer}
         author={'상대의 답변'}
-        message={girlAnswer}
+        picture={opponentProfile}
+        message={opponentAnswer}
       />
     </div>
   );

--- a/src/pages/Question/components/QuestionChat/QuestionChat.tsx
+++ b/src/pages/Question/components/QuestionChat/QuestionChat.tsx
@@ -1,8 +1,14 @@
 import QuestionChatItem from './QuestionChatItem';
+import useGetQuestion from '~/pages/Question/hooks/useGetQuestion';
 import useGetQuestionDetail from '~/pages/QuestionHistory/hooks/useGetQuestionDetail';
 
 const QuestionChat = () => {
-  const { data: { boyAnswer, girlAnswer } = {} } = useGetQuestionDetail(4);
+  const { data: question } = useGetQuestion();
+  const { data: { boyAnswer, girlAnswer } = {} } = useGetQuestionDetail(
+    question?.body?.questionId || -1,
+  );
+
+  console.log(boyAnswer, girlAnswer);
 
   return (
     <div className="mt-16">

--- a/src/pages/Question/components/QuestionChat/QuestionChatItem.tsx
+++ b/src/pages/Question/components/QuestionChat/QuestionChatItem.tsx
@@ -3,6 +3,7 @@ interface QuestionChatItemProps {
   answerStatus: boolean;
   message?: string;
   author: string;
+  picture?: string;
 }
 
 const QuestionChatItem = ({
@@ -10,6 +11,7 @@ const QuestionChatItem = ({
   answerStatus,
   author,
   message,
+  picture,
 }: QuestionChatItemProps) => {
   const chatType = type === 'start' ? 'chat-start' : 'chat-end';
   message = answerStatus === false ? '답변을 기다리는 중이에요!' : message;
@@ -18,7 +20,7 @@ const QuestionChatItem = ({
     <div className={`chat ${chatType} my-3`}>
       <div className="avatar chat-image">
         <div className="avatar-small rounded-full lg:avatar-medium">
-          <img src="https://source.unsplash.com/random/" />
+          <img src={picture} />
         </div>
       </div>
       <div className="chat-header">

--- a/src/pages/Question/components/QuestionForm/QuestionForm.tsx
+++ b/src/pages/Question/components/QuestionForm/QuestionForm.tsx
@@ -6,8 +6,12 @@ import { QuestionProvider } from '~/pages/Question/contexts/QuestionContext';
 import useGetQuestionDetail from '~/pages/QuestionHistory/hooks/useGetQuestionDetail';
 
 const QuestionForm = () => {
-  useGetQuestion();
-  const { data: { boyAnswer, girlAnswer } = {} } = useGetQuestionDetail(4);
+  const { data: question } = useGetQuestion();
+  const { data: { boyAnswer, girlAnswer } = {} } = useGetQuestionDetail(
+    question?.body?.questionId || -1,
+  );
+
+  console.log(boyAnswer, girlAnswer);
 
   return (
     <QuestionProvider>

--- a/src/pages/Question/components/QuestionForm/QuestionForm.tsx
+++ b/src/pages/Question/components/QuestionForm/QuestionForm.tsx
@@ -7,19 +7,18 @@ import useGetQuestionDetail from '~/pages/QuestionHistory/hooks/useGetQuestionDe
 
 const QuestionForm = () => {
   const { data: question } = useGetQuestion();
-  console.log(question);
-  const { data: { boyAnswer, girlAnswer } = {} } = useGetQuestionDetail(
+  const { data: questionDetail } = useGetQuestionDetail(
     question?.body?.questionId || -1,
   );
 
-  console.log(boyAnswer, girlAnswer);
+  const { myAnswer = '', opponentAnswer = '' } = questionDetail || {};
 
   return (
     <QuestionProvider>
       <div>
         <QuestionFormLabel />
         <QuestionFormSelect />
-        {boyAnswer && girlAnswer && <QuestionFormCreate />}
+        {myAnswer && opponentAnswer && <QuestionFormCreate />}
       </div>
     </QuestionProvider>
   );

--- a/src/pages/Question/components/QuestionForm/QuestionForm.tsx
+++ b/src/pages/Question/components/QuestionForm/QuestionForm.tsx
@@ -7,6 +7,7 @@ import useGetQuestionDetail from '~/pages/QuestionHistory/hooks/useGetQuestionDe
 
 const QuestionForm = () => {
   const { data: question } = useGetQuestion();
+  console.log(question);
   const { data: { boyAnswer, girlAnswer } = {} } = useGetQuestionDetail(
     question?.body?.questionId || -1,
   );

--- a/src/pages/Question/components/QuestionForm/QuestionForm.tsx
+++ b/src/pages/Question/components/QuestionForm/QuestionForm.tsx
@@ -11,14 +11,20 @@ const QuestionForm = () => {
     question?.body?.questionId || -1,
   );
 
+  const { questionFormType = '' } = question?.body || {};
   const { myAnswer = '', opponentAnswer = '' } = questionDetail || {};
+
+  const CreateForm = () =>
+    questionFormType === 'SERVER' &&
+    myAnswer &&
+    opponentAnswer && <QuestionFormCreate />;
 
   return (
     <QuestionProvider>
       <div>
         <QuestionFormLabel />
         <QuestionFormSelect />
-        {myAnswer && opponentAnswer && <QuestionFormCreate />}
+        <CreateForm />
       </div>
     </QuestionProvider>
   );

--- a/src/pages/QuestionHistory/components/HistoryList/HistoryItem.tsx
+++ b/src/pages/QuestionHistory/components/HistoryList/HistoryItem.tsx
@@ -9,10 +9,11 @@ interface QuestionDropDown {
 const HistoryItem = ({ questionTitle, questionId }: QuestionDropDown) => {
   const { data: questionDetail } = useGetQuestionDetail(questionId);
   const defaultMessage = '답변이 존재하지 않습니다!';
-  const { boyAnswer, girlAnswer } = questionDetail ?? {
-    boyAnswer: defaultMessage,
-    girlAnswer: defaultMessage,
-  };
+  const { myAnswer, opponentAnswer, myProfile, opponentProfile } =
+    questionDetail ?? {
+      myAnswer: defaultMessage,
+      opponentAnswer: defaultMessage,
+    };
 
   return (
     <div className="collapse-arrow collapse border border-solid border-grey-200 bg-base-white">
@@ -24,13 +25,15 @@ const HistoryItem = ({ questionTitle, questionId }: QuestionDropDown) => {
         <QuestionChatItem
           type={'start'}
           author={'정'}
-          message={boyAnswer}
+          message={myAnswer}
+          picture={myProfile}
           answerStatus={true}
         />
         <QuestionChatItem
           type={'end'}
           author={'호'}
-          message={girlAnswer}
+          message={opponentAnswer}
+          picture={opponentProfile}
           answerStatus={true}
         />
       </div>

--- a/src/pages/QuestionHistory/hooks/useGetQuestionDetail.ts
+++ b/src/pages/QuestionHistory/hooks/useGetQuestionDetail.ts
@@ -4,7 +4,9 @@ import apiClient from '~/api/apiClient';
 
 const useGetQuestionDetail = (questionId: number) => {
   const getQuestionDetail = async (): Promise<QuestionHistoryDetail> => {
-    const response = await apiClient.get(`/questions/details/${questionId}`);
+    const response = await apiClient.get(
+      `/questions/details/${questionId}?memberId=1&sex=MALE`,
+    );
 
     return response.data.body;
   };

--- a/src/types/question.ts
+++ b/src/types/question.ts
@@ -5,17 +5,23 @@ interface QuestionToday {
   secondChoice: string;
   thirdChoice?: string | null;
   fourthChoice?: string | null;
+  questionFormType: string;
 }
 
 interface QuestionHistoryDetail {
   questionContent: string;
-  boyAnswer: string;
-  girlAnswer: string;
+  myAnswer: string;
+  opponentAnswer: string;
+  myChoiceIndex: number;
+  opponentChoiceIndex: number;
+  myProfile: string;
+  opponentProfile: string;
 }
 
 interface QuestionHistoryPreview {
   questionId: number;
   questionContent: string;
+  questionType: string;
 }
 
 interface QuestionHistories {

--- a/src/types/question.ts
+++ b/src/types/question.ts
@@ -5,7 +5,7 @@ interface QuestionToday {
   secondChoice: string;
   thirdChoice?: string | null;
   fourthChoice?: string | null;
-  questionFormType: string;
+  questionFormType?: string;
 }
 
 interface QuestionHistoryDetail {


### PR DESCRIPTION
# 🔨 개발 사항 | 변경 사항
<!-- 무엇을 개발했는지, 변경사항이 있다면 무엇인지 알려주세요! -->

- [x] QuestionChat 이미지 추가, 나와 상대방 대답 분리
- [x] QuestionChat questionId 전달 -> 커스텀질문, 오늘의 질문 구분
- [x] QuestionForm 렌더링 조건 변경
- [x] QuestionHistory api 및 props 변경, 클릭시 조회 api 연동
- [x] api response type 변경

### 개발 사항 && 개발 스크린 샷
<!-- 커밋 단위로 잘게 나누어서 작성합시다! 개발사항1, 개발사항2... 등등 -->
* `QuestionChat` 컴포넌트에서 추가로 프로필 이미지를 전달 받을 수 있도록 코드를 수정했습니다. 추가로 `questionId`를 통해 질문 상세 정보 조회 api를 연동하도록 했습니다.
* `QuestionForm` 컴포넌트의 렌더링 조건을 변경했습니다. (오늘의 질문 type이 SERVER이고, 남여 응답을 모두 받은 상태일 때)
![image](https://github.com/Lovely-4K/love-frontend/assets/32586926/c5728d3b-9bb4-4adb-a1cb-892b2fc4ef77)

* `QuestionHistoy` 를 변경된 api에 맞게 수정했습니다. (클릭시 해당 questionId를 통해 질문 상세 정보 조회)
![image](https://github.com/Lovely-4K/love-frontend/assets/32586926/676fbfc6-2938-4627-8459-127e42e2082d)


# 📝 리뷰어들이 보면 좋을 사항
요청해주신대로 도연님께서 '질문 상세 정보 조회' api에 커플들의 프로필 이미지를 추가해주셨는데 생각해보니 날짜가 바뀐 후 처음 페이지에 입장하여 해당 api를 조회하면 데이터가 없으므로 프로필 이미지가 비어있게 됩니다... 그래서 결국 이미지를 조회를 '오늘의 질문 조회' 쪽으로 옮겨야할 것 같은데 이런 식의 api 수정 요청이 이후에도 일어날 확률이 클 것 같아서 프로필에 관련된 정보는 client에서 관리하고 있으면 어떨까합니다..!

# 🚨 이슈번호
- close #88 