### PR TITLE
 🚨HotFix: 질문 페이지 백엔드 API 연동

### DIFF
--- a/src/pages/Question/Question.tsx
+++ b/src/pages/Question/Question.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled';
 import { QuestionHeader, QuestionForm, QuestionChat } from './components';
+import { QuestionProvider } from '~/pages/Question/contexts/QuestionContext';
 
 export const QuestionContainer = styled.div`
   width: 100%;
@@ -19,8 +20,10 @@ const Question = () => {
   return (
     <QuestionContainer>
       <QuestionHeader />
-      <QuestionForm />
-      <QuestionChat />
+      <QuestionProvider>
+        <QuestionForm />
+        <QuestionChat />
+      </QuestionProvider>
     </QuestionContainer>
   );
 };

--- a/src/pages/Question/components/QuestionChat/QuestionChat.tsx
+++ b/src/pages/Question/components/QuestionChat/QuestionChat.tsx
@@ -1,19 +1,10 @@
+import useQuestion from '../../hooks/useQuestion';
 import QuestionChatItem from './QuestionChatItem';
-import useGetQuestion from '~/pages/Question/hooks/useGetQuestion';
-import useGetQuestionDetail from '~/pages/QuestionHistory/hooks/useGetQuestionDetail';
 
 const QuestionChat = () => {
-  const { data: question } = useGetQuestion();
-  const { data: questionDetail } = useGetQuestionDetail(
-    question?.body?.questionId || -1,
-  );
-
-  const {
-    myAnswer = '',
-    opponentAnswer = '',
-    myProfile = '',
-    opponentProfile = '',
-  } = questionDetail || {};
+  const { questionDetail } = useQuestion();
+  const { myAnswer, myProfile, opponentAnswer, opponentProfile } =
+    questionDetail;
 
   return (
     <div className="mt-16">

--- a/src/pages/Question/components/QuestionChat/QuestionChat.tsx
+++ b/src/pages/Question/components/QuestionChat/QuestionChat.tsx
@@ -1,22 +1,35 @@
 import QuestionChatItem from './QuestionChatItem';
+import useGetQuestion from '~/pages/Question/hooks/useGetQuestion';
 import useGetQuestionDetail from '~/pages/QuestionHistory/hooks/useGetQuestionDetail';
 
 const QuestionChat = () => {
-  const { data: { boyAnswer, girlAnswer } = {} } = useGetQuestionDetail(4);
+  const { data: question } = useGetQuestion();
+  const { data: questionDetail } = useGetQuestionDetail(
+    question?.body?.questionId || -1,
+  );
+
+  const {
+    myAnswer = '',
+    opponentAnswer = '',
+    myProfile = '',
+    opponentProfile = '',
+  } = questionDetail || {};
 
   return (
     <div className="mt-16">
       <QuestionChatItem
         type={'start'}
-        answerStatus={!!boyAnswer}
+        answerStatus={!!myAnswer}
         author={'나의 답변'}
-        message={boyAnswer}
+        picture={myProfile}
+        message={myAnswer}
       />
       <QuestionChatItem
         type={'end'}
-        answerStatus={!!girlAnswer}
+        answerStatus={!!opponentAnswer}
         author={'상대의 답변'}
-        message={girlAnswer}
+        picture={opponentProfile}
+        message={opponentAnswer}
       />
     </div>
   );

--- a/src/pages/Question/components/QuestionChat/QuestionChatItem.tsx
+++ b/src/pages/Question/components/QuestionChat/QuestionChatItem.tsx
@@ -3,6 +3,7 @@ interface QuestionChatItemProps {
   answerStatus: boolean;
   message?: string;
   author: string;
+  picture?: string;
 }
 
 const QuestionChatItem = ({
@@ -10,6 +11,7 @@ const QuestionChatItem = ({
   answerStatus,
   author,
   message,
+  picture,
 }: QuestionChatItemProps) => {
   const chatType = type === 'start' ? 'chat-start' : 'chat-end';
   message = answerStatus === false ? '답변을 기다리는 중이에요!' : message;
@@ -18,7 +20,7 @@ const QuestionChatItem = ({
     <div className={`chat ${chatType} my-3`}>
       <div className="avatar chat-image">
         <div className="avatar-small rounded-full lg:avatar-medium">
-          <img src="https://source.unsplash.com/random/" />
+          <img src={picture} />
         </div>
       </div>
       <div className="chat-header">

--- a/src/pages/Question/components/QuestionForm/QuestionForm.tsx
+++ b/src/pages/Question/components/QuestionForm/QuestionForm.tsx
@@ -1,3 +1,5 @@
+import { useEffect } from 'react';
+import useCreateTodayQuestion from '../../hooks/useCreateTodayQuestion';
 import useGetQuestion from '../../hooks/useGetQuestion';
 import QuestionFormCreate from './QuestionFormCreate';
 import QuestionFormLabel from './QuestionFormLabel';
@@ -5,6 +7,12 @@ import QuestionFormSelect from './QuestionFormSelect';
 import useGetQuestionDetail from '~/pages/QuestionHistory/hooks/useGetQuestionDetail';
 
 const QuestionForm = () => {
+  const { mutate: createTodayQuestionMutate } = useCreateTodayQuestion();
+
+  useEffect(() => {
+    createTodayQuestionMutate();
+  }, [createTodayQuestionMutate]);
+
   const { data: question } = useGetQuestion();
   const { data: questionDetail } = useGetQuestionDetail(
     question?.body?.questionId || -1,

--- a/src/pages/Question/components/QuestionForm/QuestionForm.tsx
+++ b/src/pages/Question/components/QuestionForm/QuestionForm.tsx
@@ -2,7 +2,6 @@ import useGetQuestion from '../../hooks/useGetQuestion';
 import QuestionFormCreate from './QuestionFormCreate';
 import QuestionFormLabel from './QuestionFormLabel';
 import QuestionFormSelect from './QuestionFormSelect';
-import { QuestionProvider } from '~/pages/Question/contexts/QuestionContext';
 import useGetQuestionDetail from '~/pages/QuestionHistory/hooks/useGetQuestionDetail';
 
 const QuestionForm = () => {
@@ -20,13 +19,11 @@ const QuestionForm = () => {
     opponentAnswer && <QuestionFormCreate />;
 
   return (
-    <QuestionProvider>
-      <div>
-        <QuestionFormLabel />
-        <QuestionFormSelect />
-        <CreateForm />
-      </div>
-    </QuestionProvider>
+    <div>
+      <QuestionFormLabel />
+      <QuestionFormSelect />
+      <CreateForm />
+    </div>
   );
 };
 

--- a/src/pages/Question/components/QuestionForm/QuestionForm.tsx
+++ b/src/pages/Question/components/QuestionForm/QuestionForm.tsx
@@ -1,25 +1,12 @@
-import { useEffect } from 'react';
-import useCreateTodayQuestion from '../../hooks/useCreateTodayQuestion';
-import useGetQuestion from '../../hooks/useGetQuestion';
+import useQuestion from '../../hooks/useQuestion';
 import QuestionFormCreate from './QuestionFormCreate';
 import QuestionFormLabel from './QuestionFormLabel';
 import QuestionFormSelect from './QuestionFormSelect';
-import useGetQuestionDetail from '~/pages/QuestionHistory/hooks/useGetQuestionDetail';
 
 const QuestionForm = () => {
-  const { mutate: createTodayQuestionMutate } = useCreateTodayQuestion();
-
-  useEffect(() => {
-    createTodayQuestionMutate();
-  }, [createTodayQuestionMutate]);
-
-  const { data: question } = useGetQuestion();
-  const { data: questionDetail } = useGetQuestionDetail(
-    question?.body?.questionId || -1,
-  );
-
-  const { questionFormType = '' } = question?.body || {};
-  const { myAnswer = '', opponentAnswer = '' } = questionDetail || {};
+  const { questionDetail, question } = useQuestion();
+  const { questionFormType } = question;
+  const { myAnswer, opponentAnswer } = questionDetail;
 
   const CreateForm = () =>
     questionFormType === 'SERVER' &&

--- a/src/pages/Question/components/QuestionForm/QuestionForm.tsx
+++ b/src/pages/Question/components/QuestionForm/QuestionForm.tsx
@@ -6,15 +6,25 @@ import { QuestionProvider } from '~/pages/Question/contexts/QuestionContext';
 import useGetQuestionDetail from '~/pages/QuestionHistory/hooks/useGetQuestionDetail';
 
 const QuestionForm = () => {
-  useGetQuestion();
-  const { data: { boyAnswer, girlAnswer } = {} } = useGetQuestionDetail(4);
+  const { data: question } = useGetQuestion();
+  const { data: questionDetail } = useGetQuestionDetail(
+    question?.body?.questionId || -1,
+  );
+
+  const { questionFormType = '' } = question?.body || {};
+  const { myAnswer = '', opponentAnswer = '' } = questionDetail || {};
+
+  const CreateForm = () =>
+    questionFormType === 'SERVER' &&
+    myAnswer &&
+    opponentAnswer && <QuestionFormCreate />;
 
   return (
     <QuestionProvider>
       <div>
         <QuestionFormLabel />
         <QuestionFormSelect />
-        {boyAnswer && girlAnswer && <QuestionFormCreate />}
+        <CreateForm />
       </div>
     </QuestionProvider>
   );

--- a/src/pages/Question/components/QuestionForm/QuestionFormLabel.tsx
+++ b/src/pages/Question/components/QuestionForm/QuestionFormLabel.tsx
@@ -1,7 +1,7 @@
-import useQuestionForm from '~/pages/Question/hooks/useQuestionForm';
+import useQuestion from '~/pages/Question/hooks/useQuestion';
 
 const QuestionFormLabel = () => {
-  const { questionContent } = useQuestionForm();
+  const { questionContent } = useQuestion();
 
   return (
     <div className="mt-3 flex flex-col gap-5">

--- a/src/pages/Question/components/QuestionForm/QuestionFormLabel.tsx
+++ b/src/pages/Question/components/QuestionForm/QuestionFormLabel.tsx
@@ -1,7 +1,8 @@
 import useQuestion from '~/pages/Question/hooks/useQuestion';
 
 const QuestionFormLabel = () => {
-  const { questionContent } = useQuestion();
+  const { question } = useQuestion();
+  const { questionContent } = question;
 
   return (
     <div className="mt-3 flex flex-col gap-5">

--- a/src/pages/Question/components/QuestionForm/QuestionFormSelect.tsx
+++ b/src/pages/Question/components/QuestionForm/QuestionFormSelect.tsx
@@ -3,7 +3,9 @@ import useQuestion from '~/pages/Question/hooks/useQuestion';
 
 /** @todo - 내가 직성한 값이 있는 경우 button 보이지 않거나 or 수정 버튼 보일 수 있도록 하기 */
 const QuestionFormSelect = () => {
-  const { userAnswer, answers, handleSubmitUserAnswer } = useQuestion();
+  const { userAnswer, answers, myAnswer, handleSubmitUserAnswer } =
+    useQuestion();
+  const buttonContent = myAnswer !== '' ? '수정' : '결정';
 
   return (
     <>
@@ -26,7 +28,7 @@ const QuestionFormSelect = () => {
           onClick={handleSubmitUserAnswer}
           className="btn-small btn-primary w-full rounded-xl hover:border-none hover:bg-base-secondary disabled:cursor-not-allowed disabled:bg-grey-300"
         >
-          결정
+          {buttonContent}
         </button>
       </div>
     </>

--- a/src/pages/Question/components/QuestionForm/QuestionFormSelect.tsx
+++ b/src/pages/Question/components/QuestionForm/QuestionFormSelect.tsx
@@ -1,9 +1,9 @@
 import QuestionFormSelectItem from './QuestionFormSelectItem';
-import useQuestionForm from '~/pages/Question/hooks/useQuestionForm';
+import useQuestion from '~/pages/Question/hooks/useQuestion';
 
 /** @todo - 내가 직성한 값이 있는 경우 button 보이지 않거나 or 수정 버튼 보일 수 있도록 하기 */
 const QuestionFormSelect = () => {
-  const { userAnswer, answers, handleSubmitUserAnswer } = useQuestionForm();
+  const { userAnswer, answers, handleSubmitUserAnswer } = useQuestion();
 
   return (
     <>

--- a/src/pages/Question/components/QuestionForm/QuestionFormSelectItem.tsx
+++ b/src/pages/Question/components/QuestionForm/QuestionFormSelectItem.tsx
@@ -1,4 +1,4 @@
-import useQuestionForm from '../../hooks/useQuestionForm';
+import useQuestion from '../../hooks/useQuestion';
 
 interface QuestionFormSelectItemProps {
   answer: string;
@@ -9,7 +9,7 @@ const QuestionFormSelectItem = ({
   answer,
   itemIndex,
 }: QuestionFormSelectItemProps) => {
-  const { userAnswer, setUserAnswer } = useQuestionForm();
+  const { userAnswer, setUserAnswer } = useQuestion();
   const activeStyle =
     itemIndex === userAnswer
       ? 'border-none bg-primary text-base-white hover:bg-base-secondary'

--- a/src/pages/Question/components/QuestionHeader/QuestionHeader.tsx
+++ b/src/pages/Question/components/QuestionHeader/QuestionHeader.tsx
@@ -5,7 +5,7 @@ import { CircleButton } from '~/components/common';
 const QuestionHeader = () => {
   return (
     <div className="flex justify-between">
-      <div className="lg:font-title-large font-title">오늘의 질문</div>
+      <div className="font-title lg:font-title-large">오늘의 질문</div>
       <div>
         <Link to={'/question/history'}>
           <CircleButton label="전체" icon={IconMenu} active={false} />

--- a/src/pages/Question/contexts/QuestionContext.tsx
+++ b/src/pages/Question/contexts/QuestionContext.tsx
@@ -1,12 +1,16 @@
 import React, { PropsWithChildren, createContext } from 'react';
 import { useState } from 'react';
-import { QuestionToday } from '~/types';
+import { QuestionHistoryDetail, QuestionToday } from '~/types';
 
 interface QuestionContextProps {
   userAnswer: number;
   setUserAnswer: React.Dispatch<React.SetStateAction<number>>;
   questionForm: QuestionToday;
   setQuestionForm: React.Dispatch<React.SetStateAction<QuestionToday>>;
+  questionDetail: QuestionHistoryDetail;
+  setQuestionDetail: React.Dispatch<
+    React.SetStateAction<QuestionHistoryDetail>
+  >;
 }
 
 const QuestionContext = createContext<QuestionContextProps>(
@@ -22,11 +26,28 @@ const QuestionProvider = ({ children }: PropsWithChildren) => {
     secondChoice: '선택지 2',
     thirdChoice: undefined,
     fourthChoice: undefined,
+    questionFormType: 'SERVER',
   } as QuestionToday);
+  const [questionDetail, setQuestionDetail] = useState<QuestionHistoryDetail>({
+    questionContent: '테스트 질문',
+    myAnswer: '답변을 기다리는 중이에요!',
+    opponentAnswer: '답변을 기다리는 중이에요!',
+    myChoiceIndex: 1,
+    opponentChoiceIndex: 1,
+    myProfile: '',
+    opponentProfile: '',
+  });
 
   return (
     <QuestionContext.Provider
-      value={{ userAnswer, setUserAnswer, questionForm, setQuestionForm }}
+      value={{
+        questionDetail,
+        setQuestionDetail,
+        userAnswer,
+        setUserAnswer,
+        questionForm,
+        setQuestionForm,
+      }}
     >
       {children}
     </QuestionContext.Provider>

--- a/src/pages/Question/contexts/QuestionContext.tsx
+++ b/src/pages/Question/contexts/QuestionContext.tsx
@@ -30,8 +30,8 @@ const QuestionProvider = ({ children }: PropsWithChildren) => {
   } as QuestionToday);
   const [questionDetail, setQuestionDetail] = useState<QuestionHistoryDetail>({
     questionContent: '테스트 질문',
-    myAnswer: '답변을 기다리는 중이에요!',
-    opponentAnswer: '답변을 기다리는 중이에요!',
+    myAnswer: '',
+    opponentAnswer: '',
     myChoiceIndex: 1,
     opponentChoiceIndex: 1,
     myProfile: '',

--- a/src/pages/Question/hooks/useCreateTodayQuestion.ts
+++ b/src/pages/Question/hooks/useCreateTodayQuestion.ts
@@ -1,5 +1,5 @@
 import { useMutation, QueryClient } from '@tanstack/react-query';
-import axios from 'axios';
+import apiClient from '~/api/apiClient';
 
 const queryClient = new QueryClient();
 
@@ -8,19 +8,19 @@ const useCreateTodayQuestion = () => {
     const subURL = '/questions';
     const params = '?coupleId=1';
     const URL = subURL + params;
-    const response = await axios.post(URL, { data: {} });
+    const response = await apiClient.post(URL, { data: {} });
 
     return response.data;
   };
 
-  const { data, isError } = useMutation({
+  const { mutate, data, isError } = useMutation({
     mutationFn: createTodayQuestion,
     onSettled: async () => {
       await queryClient.invalidateQueries({ queryKey: ['question'] });
     },
   });
 
-  return { data, isError };
+  return { mutate, data, isError };
 };
 
 export default useCreateTodayQuestion;

--- a/src/pages/Question/hooks/useGetQuestion.ts
+++ b/src/pages/Question/hooks/useGetQuestion.ts
@@ -15,12 +15,12 @@ const useGetQuestion = () => {
     return response.data;
   };
 
-  const { data, isError, isLoading } = useQuery({
+  const { data, isError, isLoading, isSuccess } = useQuery({
     queryKey: ['question'],
     queryFn: getQuestion,
   });
 
-  return { data, isError, isLoading };
+  return { data, isError, isLoading, isSuccess };
 };
 
 export default useGetQuestion;

--- a/src/pages/Question/hooks/useQuestion.tsx
+++ b/src/pages/Question/hooks/useQuestion.tsx
@@ -16,11 +16,12 @@ const useQuestion = () => {
   } = useContext(QuestionContext);
   const { mutate: createTodayQuestionMutate } = useCreateTodayQuestion();
   const { data: questionResponse } = useGetQuestion();
-  const { data: questionDetailResponse } = useGetQuestionDetail(
-    questionResponse?.body?.questionId || -1,
-  );
-  const { mutate: mutateUserAnswer } = useUpdateUserAnswer();
+  const { data: questionDetailResponse, refetch: questionDetailRefetch } =
+    useGetQuestionDetail(questionResponse?.body?.questionId || -1);
+  const { data: updateAnswerResponse, mutate: mutateUserAnswer } =
+    useUpdateUserAnswer();
 
+  const { myAnswer } = questionDetail;
   const {
     questionId,
     questionContent,
@@ -47,6 +48,13 @@ const useQuestion = () => {
     }
   }, [questionDetailResponse, setQuestionDetail]);
 
+  useEffect(() => {
+    if (updateAnswerResponse !== undefined) {
+      alert('답변을 제출했습니다!');
+      questionDetailRefetch().catch((error) => console.log(error));
+    }
+  }, [updateAnswerResponse, questionDetailRefetch]);
+
   const handleSubmitUserAnswer = () => {
     if (questionId) {
       mutateUserAnswer({
@@ -61,6 +69,7 @@ const useQuestion = () => {
     questionDetail,
     userAnswer,
     setUserAnswer,
+    myAnswer,
     handleSubmitUserAnswer,
     question: {
       questionId,

--- a/src/pages/Question/hooks/useQuestion.tsx
+++ b/src/pages/Question/hooks/useQuestion.tsx
@@ -62,6 +62,11 @@ const useQuestion = () => {
         selectedItemIndex: userAnswer,
         sex: 'MALE',
       });
+      mutateUserAnswer({
+        questionId,
+        selectedItemIndex: userAnswer,
+        sex: 'FEMALE',
+      });
     }
   };
 

--- a/src/pages/Question/hooks/useQuestion.tsx
+++ b/src/pages/Question/hooks/useQuestion.tsx
@@ -34,7 +34,7 @@ const useQuestion = () => {
 
   useEffect(() => {
     createTodayQuestionMutate();
-  }, []);
+  }, [createTodayQuestionMutate]);
 
   useEffect(() => {
     if (questionResponse) {

--- a/src/pages/Question/hooks/useQuestion.tsx
+++ b/src/pages/Question/hooks/useQuestion.tsx
@@ -1,13 +1,26 @@
 import { useContext, useEffect } from 'react';
 import { QuestionContext } from '../contexts/QuestionContext';
+import useCreateTodayQuestion from './useCreateTodayQuestion';
 import useGetQuestion from './useGetQuestion';
 import useUpdateUserAnswer from './useUpdateUserAnswer';
+import useGetQuestionDetail from '~/pages/QuestionHistory/hooks/useGetQuestionDetail';
 
 const useQuestion = () => {
+  const {
+    questionDetail,
+    setQuestionDetail,
+    userAnswer,
+    setUserAnswer,
+    questionForm,
+    setQuestionForm,
+  } = useContext(QuestionContext);
+  const { mutate: createTodayQuestionMutate } = useCreateTodayQuestion();
   const { data: questionResponse } = useGetQuestion();
+  const { data: questionDetailResponse } = useGetQuestionDetail(
+    questionResponse?.body?.questionId || -1,
+  );
   const { mutate: mutateUserAnswer } = useUpdateUserAnswer();
-  const { userAnswer, setUserAnswer, questionForm, setQuestionForm } =
-    useContext(QuestionContext);
+
   const {
     questionId,
     questionContent,
@@ -15,14 +28,24 @@ const useQuestion = () => {
     secondChoice,
     thirdChoice,
     fourthChoice,
+    questionFormType,
   } = questionForm;
 
   useEffect(() => {
-    console.log(questionResponse);
+    createTodayQuestionMutate();
+  }, []);
+
+  useEffect(() => {
     if (questionResponse) {
       setQuestionForm(questionResponse.body);
     }
   }, [questionResponse, setQuestionForm]);
+
+  useEffect(() => {
+    if (questionDetailResponse) {
+      setQuestionDetail(questionDetailResponse.body);
+    }
+  }, [questionDetailResponse, setQuestionDetail]);
 
   const handleSubmitUserAnswer = () => {
     if (questionId) {
@@ -35,11 +58,15 @@ const useQuestion = () => {
   };
 
   return {
+    questionDetail,
     userAnswer,
     setUserAnswer,
     handleSubmitUserAnswer,
-    questionId,
-    questionContent,
+    question: {
+      questionId,
+      questionContent,
+      questionFormType,
+    },
     answers: [firstChoice, secondChoice, thirdChoice, fourthChoice],
   };
 };

--- a/src/pages/Question/hooks/useQuestion.tsx
+++ b/src/pages/Question/hooks/useQuestion.tsx
@@ -2,10 +2,8 @@ import { useContext, useEffect } from 'react';
 import { QuestionContext } from '../contexts/QuestionContext';
 import useGetQuestion from './useGetQuestion';
 import useUpdateUserAnswer from './useUpdateUserAnswer';
-import useCreateForm from '~/pages/QuestionCreate/hooks/useCreateForm';
 
 const useQuestion = () => {
-  useCreateForm();
   const { data: questionResponse } = useGetQuestion();
   const { mutate: mutateUserAnswer } = useUpdateUserAnswer();
   const { userAnswer, setUserAnswer, questionForm, setQuestionForm } =

--- a/src/pages/Question/hooks/useQuestion.tsx
+++ b/src/pages/Question/hooks/useQuestion.tsx
@@ -2,8 +2,10 @@ import { useContext, useEffect } from 'react';
 import { QuestionContext } from '../contexts/QuestionContext';
 import useGetQuestion from './useGetQuestion';
 import useUpdateUserAnswer from './useUpdateUserAnswer';
+import useCreateForm from '~/pages/QuestionCreate/hooks/useCreateForm';
 
-const useQuestionForm = () => {
+const useQuestion = () => {
+  useCreateForm();
   const { data: questionResponse } = useGetQuestion();
   const { mutate: mutateUserAnswer } = useUpdateUserAnswer();
   const { userAnswer, setUserAnswer, questionForm, setQuestionForm } =
@@ -18,6 +20,7 @@ const useQuestionForm = () => {
   } = questionForm;
 
   useEffect(() => {
+    console.log(questionResponse);
     if (questionResponse) {
       setQuestionForm(questionResponse.body);
     }
@@ -43,4 +46,4 @@ const useQuestionForm = () => {
   };
 };
 
-export default useQuestionForm;
+export default useQuestion;

--- a/src/pages/Question/hooks/useQuestionForm.tsx
+++ b/src/pages/Question/hooks/useQuestionForm.tsx
@@ -24,7 +24,13 @@ const useQuestionForm = () => {
   }, [questionResponse, setQuestionForm]);
 
   const handleSubmitUserAnswer = () => {
-    mutateUserAnswer({ selectedItemIndex: userAnswer, sex: 'MALE' });
+    if (questionId) {
+      mutateUserAnswer({
+        questionId,
+        selectedItemIndex: userAnswer,
+        sex: 'MALE',
+      });
+    }
   };
 
   return {

--- a/src/pages/Question/hooks/useUpdateUserAnswer.ts
+++ b/src/pages/Question/hooks/useUpdateUserAnswer.ts
@@ -1,5 +1,5 @@
 import { useMutation, QueryClient } from '@tanstack/react-query';
-import axios from 'axios';
+import apiClient from '~/api/apiClient';
 
 interface updateUserAnswerParams {
   questionId: number;
@@ -18,9 +18,15 @@ const useUpdateUserAnswer = () => {
     const subURL = `/questions/${questionId}`;
     const params = `/answers?sex=${sex}`;
     const URL = subURL + params;
-    const response = await axios.patch(URL, {
-      data: { choiceNumber: selectedItemIndex },
-    });
+    const response = await apiClient.patch(
+      URL,
+      JSON.stringify({ choiceNumber: selectedItemIndex }),
+      {
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      },
+    );
 
     return response.data;
   };

--- a/src/pages/Question/hooks/useUpdateUserAnswer.ts
+++ b/src/pages/Question/hooks/useUpdateUserAnswer.ts
@@ -2,6 +2,7 @@ import { useMutation, QueryClient } from '@tanstack/react-query';
 import axios from 'axios';
 
 interface updateUserAnswerParams {
+  questionId: number;
   selectedItemIndex: number;
   sex: 'MALE' | 'FEMALE';
 }
@@ -10,10 +11,11 @@ const queryClient = new QueryClient();
 
 const useUpdateUserAnswer = () => {
   const updateUserAnswer = async ({
+    questionId,
     selectedItemIndex,
     sex,
   }: updateUserAnswerParams) => {
-    const subURL = '/questions/1';
+    const subURL = `/questions/${questionId}`;
     const params = `/answers?sex=${sex}`;
     const URL = subURL + params;
     const response = await axios.patch(URL, {

--- a/src/pages/QuestionCreate/hooks/useCreateForm.ts
+++ b/src/pages/QuestionCreate/hooks/useCreateForm.ts
@@ -17,7 +17,6 @@ const useCreateForm = () => {
     const subURL = 'questions/question-forms?';
     const params = `memberId=${1}&coupleId=${1}`;
     const URL = subURL + params;
-    console.log(questionForm);
     const response = await apiClient.post<QuestionResponse>(
       URL,
       JSON.stringify(questionForm),

--- a/src/pages/QuestionHistory/components/HistoryList/HistoryItem.tsx
+++ b/src/pages/QuestionHistory/components/HistoryList/HistoryItem.tsx
@@ -9,10 +9,11 @@ interface QuestionDropDown {
 const HistoryItem = ({ questionTitle, questionId }: QuestionDropDown) => {
   const { data: questionDetail } = useGetQuestionDetail(questionId);
   const defaultMessage = '답변이 존재하지 않습니다!';
-  const { boyAnswer, girlAnswer } = questionDetail ?? {
-    boyAnswer: defaultMessage,
-    girlAnswer: defaultMessage,
-  };
+  const { myAnswer, opponentAnswer, myProfile, opponentProfile } =
+    questionDetail ?? {
+      myAnswer: defaultMessage,
+      opponentAnswer: defaultMessage,
+    };
 
   return (
     <div className="collapse-arrow collapse border border-solid border-grey-200 bg-base-white">
@@ -24,13 +25,15 @@ const HistoryItem = ({ questionTitle, questionId }: QuestionDropDown) => {
         <QuestionChatItem
           type={'start'}
           author={'정'}
-          message={boyAnswer}
+          message={myAnswer}
+          picture={myProfile}
           answerStatus={true}
         />
         <QuestionChatItem
           type={'end'}
           author={'호'}
-          message={girlAnswer}
+          message={opponentAnswer}
+          picture={opponentProfile}
           answerStatus={true}
         />
       </div>

--- a/src/pages/QuestionHistory/components/HistoryList/HistoryItem.tsx
+++ b/src/pages/QuestionHistory/components/HistoryList/HistoryItem.tsx
@@ -7,10 +7,10 @@ interface QuestionDropDown {
 }
 
 const HistoryItem = ({ questionTitle, questionId }: QuestionDropDown) => {
-  const { data: questionDetail } = useGetQuestionDetail(questionId);
+  const { data: questionDetailResponse } = useGetQuestionDetail(questionId);
   const defaultMessage = '답변이 존재하지 않습니다!';
   const { myAnswer, opponentAnswer, myProfile, opponentProfile } =
-    questionDetail ?? {
+    questionDetailResponse?.body ?? {
       myAnswer: defaultMessage,
       opponentAnswer: defaultMessage,
     };

--- a/src/pages/QuestionHistory/hooks/useGetQuestionDetail.ts
+++ b/src/pages/QuestionHistory/hooks/useGetQuestionDetail.ts
@@ -1,17 +1,25 @@
 import { useQuery } from '@tanstack/react-query';
-import { QuestionHistoryDetail } from '~/types';
+import { QuestionHistoryDetail, code, links } from '~/types';
 import apiClient from '~/api/apiClient';
 
-const useGetQuestionDetail = (questionId: number) => {
-  const getQuestionDetail = async (): Promise<QuestionHistoryDetail> => {
-    const response = await apiClient.get(
-      `/questions/details/${questionId}?memberId=1&sex=MALE`,
-    );
+interface QuestionHistoryDetailResponse {
+  code: code;
+  links: links;
+  body: QuestionHistoryDetail;
+}
 
-    return response.data.body;
-  };
+const useGetQuestionDetail = (questionId: number) => {
+  const getQuestionDetail =
+    async (): Promise<QuestionHistoryDetailResponse> => {
+      const response = await apiClient.get(
+        `/questions/details/${questionId}?memberId=1&sex=MALE`,
+      );
+
+      return response.data;
+    };
 
   const { data, isError, isLoading } = useQuery({
+    enabled: questionId !== -1,
     queryKey: ['questionDetail', questionId],
     queryFn: getQuestionDetail,
   });

--- a/src/pages/QuestionHistory/hooks/useGetQuestionDetail.ts
+++ b/src/pages/QuestionHistory/hooks/useGetQuestionDetail.ts
@@ -4,7 +4,9 @@ import apiClient from '~/api/apiClient';
 
 const useGetQuestionDetail = (questionId: number) => {
   const getQuestionDetail = async (): Promise<QuestionHistoryDetail> => {
-    const response = await apiClient.get(`/questions/details/${questionId}`);
+    const response = await apiClient.get(
+      `/questions/details/${questionId}?memberId=1&sex=MALE`,
+    );
 
     return response.data.body;
   };

--- a/src/pages/QuestionHistory/hooks/useGetQuestionDetail.ts
+++ b/src/pages/QuestionHistory/hooks/useGetQuestionDetail.ts
@@ -18,13 +18,13 @@ const useGetQuestionDetail = (questionId: number) => {
       return response.data;
     };
 
-  const { data, isError, isLoading } = useQuery({
+  const { data, isError, isLoading, refetch } = useQuery({
     enabled: questionId !== -1,
     queryKey: ['questionDetail', questionId],
     queryFn: getQuestionDetail,
   });
 
-  return { data, isError, isLoading };
+  return { data, isError, isLoading, refetch };
 };
 
 export default useGetQuestionDetail;

--- a/src/types/question.ts
+++ b/src/types/question.ts
@@ -5,17 +5,23 @@ interface QuestionToday {
   secondChoice: string;
   thirdChoice?: string | null;
   fourthChoice?: string | null;
+  questionFormType?: string;
 }
 
 interface QuestionHistoryDetail {
   questionContent: string;
-  boyAnswer: string;
-  girlAnswer: string;
+  myAnswer: string;
+  opponentAnswer: string;
+  myChoiceIndex: number;
+  opponentChoiceIndex: number;
+  myProfile: string;
+  opponentProfile: string;
 }
 
 interface QuestionHistoryPreview {
   questionId: number;
   questionContent: string;
+  questionType: string;
 }
 
 interface QuestionHistories {


### PR DESCRIPTION
# 🔨 개발 사항 | 변경 사항

수정된 백엔드 API 연동과 관련된 오류를 확인하고 정상 동작하는 것을 확인했습니다.

### 주요 수정 사항

- useQuestionForm 을 useQuestion 으로 변경했습니다.
- QuestionForm 과 QuestionChat 의 생명주기를 같다고 판단하여 같은 Context 로 데이터를 제공받습니다.

### 질문 생성 API

- 질문 생성을 처리하는 코드가 아무 데서도 호출 되지 않아 나는 오류를 해결했습니다.
- 질문 생성 실패 or 성공 여부와 상관없이 질문 조회를 호출합니다. (실패 -> 이미 질문이 생성된 상태, 성공 -> 질문 생성 완료)

### 질문 조회 API & 질문 상세 조회 API

- 질문 조회 & 질문 상세 정보 조회를 모두 같은 Context 에서 제공합니다.
- 질문 조회를 통해 받아온 `questionId` 가 없어 해당 값이 `-1` 이면 질문 상세 조회 API 를 호출하지 않습니다.

### 답변 제출 API

-  `axios` 사용 시 `apiClient` 를 사용합니다.
-  body, header 값을 재설정해주었습니다.
- 사용자가 답변을 제출하면 `refetch` 함수를 호출하여 다시 상세정보를 받아옵니다.
- 이미 제출한 답변이 있으면 `수정` 버튼을, 없다면 `결정` 버튼을 보여줍니다.

### 개발 스크린 샷

<img width="690" alt="image" src="https://github.com/Lovely-4K/love-frontend/assets/80307321/be781444-6d1f-44c2-b583-189ef048435f">

# 📝 리뷰어들이 보면 좋을 사항

### 기타
- 정호님 (#89 ) 의 로직을 merge 하여 코드를 추가했습니다.

### 추후 업그레이드
- Context API 의 사용으로 인해 렌더링이 너무 많이 발생하고 있습니다. 성능 최적화를 해야합니다 ㅠㅠ
- 추후 질문 생성 API 호출 시 에러 코드를 세분화 하여 질문 조회를 해야합니다.
- Error 발생 시 UI 를 추가해야 합니다.
- Loading 시 Skeleton 혹은 Loader 를 사용하는 UI 를 추가해야합니다.

# 🚨 이슈번호

- close #87 
