### PR TITLE
💄 Style: 사이드바 css 수정 (붕 뜨는 문제 및 arrow 아이콘 rotate 문제)

### DIFF
--- a/src/pages/Diary/components/DiaryCommon/DiarySideBar.tsx
+++ b/src/pages/Diary/components/DiaryCommon/DiarySideBar.tsx
@@ -13,6 +13,8 @@ const DiarySideBar = () => {
     ? 'translate-y-0 lg:translate-x-0'
     : 'translate-y-full h-0 lg:-translate-x-[98%] lg:translate-y-0';
 
+  const arrowStyle = isOpen ? 'rotate-180 lg:-rotate-90' : 'lg:rotate-90';
+
   return (
     <div
       className={`absolute bottom-24 z-30 flex h-[23rem] w-full justify-center rounded-t-xl bg-base-white p-7 shadow-[0rem_-0.15rem_0.15rem_0rem_rgba(0,0,0,0.25)] transition-all duration-300 lg:bottom-0 lg:left-28 lg:h-screen lg:w-[23rem] lg:rounded-r-xl lg:shadow-[0.15rem_0.15rem_0.15rem_0rem_rgba(0,0,0,0.25)] ${openStyle}`}
@@ -21,11 +23,7 @@ const DiarySideBar = () => {
         className="absolute bottom-full flex h-7 w-10 items-center justify-center rounded-t-xl border-2 border-b-0 border-grey-300 bg-base-white text-xl text-base-black lg:left-full lg:top-1/2 lg:h-10 lg:w-7 lg:rounded-l-none lg:rounded-r-xl lg:border-b-2 lg:border-l-0"
         onClick={toggleSideBar}
       >
-        <IconTopArrow
-          className={`h-4 w-4 fill-grey-400 lg:rotate-90 ${
-            isOpen && 'rotate-180 lg:-rotate-90'
-          }`}
-        />
+        <IconTopArrow className={`h-4 w-4 fill-grey-400 ${arrowStyle}`} />
       </button>
       <DiaryContent />
     </div>

--- a/src/pages/Diary/components/DiaryCommon/DiarySideBar.tsx
+++ b/src/pages/Diary/components/DiaryCommon/DiarySideBar.tsx
@@ -11,11 +11,11 @@ const DiarySideBar = () => {
 
   const openStyle = isOpen
     ? 'translate-y-0 lg:translate-x-0'
-    : 'translate-y-[105%] lg:-translate-x-[98%] lg:translate-y-0';
+    : 'translate-y-full h-0 lg:-translate-x-[98%] lg:translate-y-0';
 
   return (
     <div
-      className={`absolute bottom-28 z-30 flex h-[23rem] w-full justify-center rounded-t-xl bg-base-white p-7 shadow-[0rem_-0.15rem_0.15rem_0rem_rgba(0,0,0,0.25)] transition-all duration-300 lg:bottom-0 lg:left-28 lg:h-screen lg:w-[23rem] lg:rounded-r-xl lg:shadow-[0.15rem_0.15rem_0.15rem_0rem_rgba(0,0,0,0.25)] ${openStyle}`}
+      className={`absolute bottom-24 z-30 flex h-[23rem] w-full justify-center rounded-t-xl bg-base-white p-7 shadow-[0rem_-0.15rem_0.15rem_0rem_rgba(0,0,0,0.25)] transition-all duration-300 lg:bottom-0 lg:left-28 lg:h-screen lg:w-[23rem] lg:rounded-r-xl lg:shadow-[0.15rem_0.15rem_0.15rem_0rem_rgba(0,0,0,0.25)] ${openStyle}`}
     >
       <button
         className="absolute bottom-full flex h-7 w-10 items-center justify-center rounded-t-xl border-2 border-b-0 border-grey-300 bg-base-white text-xl text-base-black lg:left-full lg:top-1/2 lg:h-10 lg:w-7 lg:rounded-l-none lg:rounded-r-xl lg:border-b-2 lg:border-l-0"


### PR DESCRIPTION
# 🔨 개발 사항 | 변경 사항
<!-- 무엇을 개발했는지, 변경사항이 있다면 무엇인지 알려주세요! -->
* 기존 사이드바의 css를 수정했습니다. (붕 뜨는 문제 해결, open / close시 rotate 변경)

### 개발 사항
<!-- 커밋 단위로 잘게 나누어서 작성합시다! 개발사항1, 개발사항2... 등등 -->
* 사이드바 붕 뜨는 문제 해결 및 스크롤바 보이는 에러 해결
![image](https://github.com/Lovely-4K/love-frontend/assets/32586926/14fb7456-8a82-479a-9a85-a21dbd87c1ef)

* 웹 뷰에서 사이드바 open, close시 버튼이 제대로 rotate되지 않는 문제를 해결
![image](https://github.com/Lovely-4K/love-frontend/assets/32586926/2e12237c-cdd3-49fb-a615-d1170a9a9a8c)
![image](https://github.com/Lovely-4K/love-frontend/assets/32586926/d5e676fb-ea6a-4400-a1ec-44004e083d86)


# 📝 리뷰어들이 보면 좋을 사항

지금 사이드바 내부 코드가 이런 식으로 되어있는데 삼항 연산자로 style을 설정하는 부분과 `useState` 부분이 같이 있어서 고민입니다. return문 윗 부분 내부에서 스타일 내역을 로직과 분리해서 모두 아래 혹은 위로 모아둬야 할 것 같은데 어디가 좋을까요? (현재는 아래 모아두었습니다.
 
```tsx
const DiarySideBar = () => {
  const [isOpen, setIsOpen] = useState(true);

  const toggleSideBar = () => {
    setIsOpen(!isOpen);
  };

  const openStyle = isOpen
    ? 'translate-y-0 lg:translate-x-0'
    : 'translate-y-full h-0 lg:-translate-x-[98%] lg:translate-y-0';

  const arrowStyle = isOpen ? 'rotate-180 lg:-rotate-90' : 'lg:rotate-90';

  return (
    <div
.......
```

# 🚨 이슈번호
- close #96 