### PR TITLE
✨ Feat: SettingPage 추가

### DIFF
--- a/src/pages/Setting/Setting.tsx
+++ b/src/pages/Setting/Setting.tsx
@@ -1,0 +1,17 @@
+import { SettingContent, SettingTab } from './components';
+import { SettingProvider } from './contexts';
+
+const Setting = () => {
+  return (
+    <SettingProvider>
+      <div className="h-full w-full px-8 py-7 lg:px-14">
+        <h1 className="mb-6 text-xl lg:text-2xl">환경설정</h1>
+        <SettingTab />
+        <div className="absolute left-0 w-full -translate-y-[2px] border-b-2 border-grey-300" />
+        <SettingContent />
+      </div>
+    </SettingProvider>
+  );
+};
+
+export default Setting;

--- a/src/pages/Setting/components/SettingContent/ContentItem.tsx
+++ b/src/pages/Setting/components/SettingContent/ContentItem.tsx
@@ -1,0 +1,31 @@
+import { Button } from '~/components/common';
+
+interface ContentItemProps {
+  title: string;
+  description: string;
+  buttonName: string;
+  handleButtonClick: () => void;
+}
+
+const ContentItem = ({
+  title,
+  description,
+  buttonName,
+  handleButtonClick,
+}: ContentItemProps) => {
+  return (
+    <div className="flex h-4/5 w-full flex-col items-center justify-center">
+      <div className="text-[6.25rem]">{title}</div>
+      <div className="mb-10 whitespace-pre-line text-center">{description}</div>
+      <Button
+        size="large"
+        className=" bg-base-primary text-base-white"
+        onClick={handleButtonClick}
+      >
+        {buttonName}
+      </Button>
+    </div>
+  );
+};
+
+export default ContentItem;

--- a/src/pages/Setting/components/SettingContent/SettingContent.tsx
+++ b/src/pages/Setting/components/SettingContent/SettingContent.tsx
@@ -1,0 +1,41 @@
+import { useSetting } from '../../hooks';
+import ContentItem from './ContentItem';
+
+const SettingContent = () => {
+  const { activeTab, handleLogout } = useSetting();
+
+  if (activeTab === 'LOGOUT') {
+    return (
+      <ContentItem
+        title="💔"
+        buttonName="로그아웃"
+        description={`정말 로그아웃 하시겠어요?\n로그아웃 후에도 커플은 유지돼요.`}
+        handleButtonClick={handleLogout}
+      />
+    );
+  }
+
+  if (activeTab === 'INACTIVE') {
+    return (
+      <ContentItem
+        title="🔓"
+        buttonName="비활성화"
+        description={`커플을 비활성화 하시겠어요?\n최대 30일까지 커플의 기록이 보존돼요.`}
+        handleButtonClick={() => {}}
+      />
+    );
+  }
+
+  if (activeTab === 'CANCEL') {
+    return (
+      <ContentItem
+        title="😭"
+        buttonName="탈퇴"
+        description={`정말 계정을 탈퇴하시겠어요?\n 모든 기록이 삭제되어 복구할 수 없어요.`}
+        handleButtonClick={() => {}}
+      />
+    );
+  }
+};
+
+export default SettingContent;

--- a/src/pages/Setting/components/SettingTab.tsx
+++ b/src/pages/Setting/components/SettingTab.tsx
@@ -1,12 +1,13 @@
 import styled from '@emotion/styled';
 import { Fragment } from 'react';
-import { colors, fontSize } from '~/theme';
+import { colors, fontSize, screens } from '~/theme';
 import { SETTING_TAB } from '../constants';
 import { useSetting } from '../hooks';
 
 const StyledTab = styled.label`
-  font-size: ${() => fontSize.base};
-  width: 7rem;
+  font-size: ${() => fontSize.sm};
+  width: 6rem;
+  height: 2rem;
   text-align: center;
   font-weight: 100;
   padding: 0.5rem;
@@ -16,6 +17,11 @@ const StyledTab = styled.label`
     font-weight: 700;
     border-bottom: 3px solid ${colors.base.primary};
     color: ${colors.base.primary};
+  }
+  @media (min-width: ${screens.lg}) {
+    font-size: ${fontSize.base};
+    height: 2.5rem;
+    width: 7rem;
   }
 `;
 

--- a/src/pages/Setting/components/SettingTab.tsx
+++ b/src/pages/Setting/components/SettingTab.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 import { Fragment } from 'react';
-import { colors, fontSize, screens } from '~/theme';
+import { colors, fontSize } from '~/theme';
 import { SETTING_TAB } from '../constants';
 import { useSetting } from '../hooks';
 

--- a/src/pages/Setting/components/SettingTab.tsx
+++ b/src/pages/Setting/components/SettingTab.tsx
@@ -1,0 +1,46 @@
+import styled from '@emotion/styled';
+import { Fragment } from 'react';
+import { colors, fontSize, screens } from '~/theme';
+import { SETTING_TAB } from '../constants';
+import { useSetting } from '../hooks';
+
+const StyledTab = styled.label`
+  font-size: ${() => fontSize.base};
+  width: 7rem;
+  text-align: center;
+  font-weight: 100;
+  padding: 0.5rem;
+  cursor: pointer;
+  z-index: 1;
+  input[type='radio']:checked + & {
+    font-weight: 700;
+    border-bottom: 3px solid ${colors.base.primary};
+    color: ${colors.base.primary};
+  }
+`;
+
+const SettingTab = () => {
+  const { activeTab, handleTabChange } = useSetting();
+
+  return (
+    <div className="flex">
+      {Object.keys(SETTING_TAB).map((tab) => (
+        <Fragment key={tab}>
+          <input
+            type="radio"
+            id={tab}
+            name="setting_tab"
+            className="hidden"
+            checked={activeTab === tab}
+            onChange={() => handleTabChange(tab as keyof typeof SETTING_TAB)}
+          />
+          <StyledTab htmlFor={tab}>
+            {SETTING_TAB[tab as keyof typeof SETTING_TAB]}
+          </StyledTab>
+        </Fragment>
+      ))}
+    </div>
+  );
+};
+
+export default SettingTab;

--- a/src/pages/Setting/components/index.ts
+++ b/src/pages/Setting/components/index.ts
@@ -1,0 +1,2 @@
+export { default as SettingTab } from './SettingTab';
+export { default as SettingContent } from './SettingContent/SettingContent';

--- a/src/pages/Setting/constants/index.ts
+++ b/src/pages/Setting/constants/index.ts
@@ -1,0 +1,1 @@
+export { default as SETTING_TAB } from './settingTab';

--- a/src/pages/Setting/constants/settingTab.ts
+++ b/src/pages/Setting/constants/settingTab.ts
@@ -1,0 +1,7 @@
+const SETTING_TAB = {
+  LOGOUT: '로그아웃',
+  INACTIVE: '커플 비활성화',
+  CANCEL: '회원 탈퇴',
+} as const;
+
+export default SETTING_TAB;

--- a/src/pages/Setting/contexts/SettingContext.tsx
+++ b/src/pages/Setting/contexts/SettingContext.tsx
@@ -1,0 +1,46 @@
+import {
+  PropsWithChildren,
+  createContext,
+  useCallback,
+  useMemo,
+  useState,
+} from 'react';
+import { useNavigate } from 'react-router-dom';
+import { SETTING_TAB } from '../constants';
+
+interface SettingContextProps {
+  activeTab: keyof typeof SETTING_TAB;
+  handleTabChange: (tab: keyof typeof SETTING_TAB) => void;
+  handleLogout(): void;
+}
+
+const SettingContext = createContext<SettingContextProps | null>(null);
+
+const SettingProvider = ({ children }: PropsWithChildren) => {
+  const [activeTab, setActiveTab] =
+    useState<keyof typeof SETTING_TAB>('LOGOUT');
+  const navigate = useNavigate();
+
+  const handleTabChange = useCallback((tab: keyof typeof SETTING_TAB) => {
+    setActiveTab(tab);
+  }, []);
+
+  const handleLogout = useCallback(() => {
+    navigate('/login');
+  }, [navigate]);
+
+  const value = useMemo(
+    () => ({
+      activeTab,
+      handleTabChange,
+      handleLogout,
+    }),
+    [activeTab, handleTabChange, handleLogout],
+  );
+
+  return (
+    <SettingContext.Provider value={value}>{children}</SettingContext.Provider>
+  );
+};
+
+export { SettingContext, SettingProvider };

--- a/src/pages/Setting/contexts/index.ts
+++ b/src/pages/Setting/contexts/index.ts
@@ -1,0 +1,1 @@
+export { SettingContext, SettingProvider } from './SettingContext';

--- a/src/pages/Setting/hooks/index.ts
+++ b/src/pages/Setting/hooks/index.ts
@@ -1,0 +1,1 @@
+export { default as useSetting } from './useSetting';

--- a/src/pages/Setting/hooks/useSetting.ts
+++ b/src/pages/Setting/hooks/useSetting.ts
@@ -1,0 +1,12 @@
+import { useContext } from 'react';
+import { SettingContext } from '../contexts';
+
+const useSetting = () => {
+  const settingContext = useContext(SettingContext);
+
+  if (!settingContext) throw new Error('Cannot find SettingProvider');
+
+  return settingContext;
+};
+
+export default useSetting;

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -5,3 +5,4 @@ export * from './Question';
 export * from './QuestionHistory';
 export * from './QuestionCreate';
 export * from './Diary';
+export { default as Setting } from './Setting/Setting';

--- a/src/router/router.tsx
+++ b/src/router/router.tsx
@@ -7,6 +7,7 @@ import {
   Question,
   QuestionCreate,
   QuestionHistory,
+  Setting,
 } from '~/pages';
 import Layout from './Layout';
 import PATHS from './paths';
@@ -42,6 +43,10 @@ const router = createBrowserRouter([
           {
             path: PATHS.QUESTION_HISTORY,
             element: <QuestionHistory />,
+          },
+          {
+            path: PATHS.SETTING,
+            element: <Setting />,
           },
         ],
       },


### PR DESCRIPTION
# 🔨 개발 사항 | 변경 사항
<!-- 무엇을 개발했는지, 변경사항이 있다면 무엇인지 알려주세요! -->

<img width="1347" alt="스크린샷 2023-11-24 오후 6 24 24" src="https://github.com/Lovely-4K/love-frontend/assets/45515388/d724a67e-0af4-4af3-9ef9-dd967d9150e4">

setting 페이지의 기초 개발을 완료했습니다.
현재 로그아웃, 커플 비활성화, 탈퇴 기능 API가 docs에 추가된 상태가 아니여서 기본적인 부분만 구현하였습니다.

daisy UI의 Tabs를 사용하려했으나 tailwindcss 스타일이 적용되지 않는 문제가 발생해서 직접 구현했습니다.


# 🚨 이슈번호
- close #124 
