### PR TITLE
✨ Feat: Diary 다중 삭제 연동 및 검색 로직 수정

### DIFF
--- a/src/api/apiClient.ts
+++ b/src/api/apiClient.ts
@@ -6,7 +6,7 @@ const apiClient = axios.create({
 });
 
 apiClient.interceptors.request.use((config) => {
-  const token = getValueFromStorage('token');
+  const token = getValueFromStorage('accessToken');
 
   if (token) {
     config.headers.Authorization = `Bearer ${token}`;

--- a/src/hooks/useLogin.ts
+++ b/src/hooks/useLogin.ts
@@ -2,11 +2,11 @@ import { saveValueToStorage, getValueFromStorage } from '~/utils/localStorage';
 
 const useLogin = (token: string | null) => {
   if (token !== null) {
-    saveValueToStorage('token', token);
+    saveValueToStorage('accessToken', token);
   }
 
   const isLoggedIn = () => {
-    const storageToken = getValueFromStorage('token');
+    const storageToken = getValueFromStorage('accessToken');
 
     return storageToken !== null && storageToken !== undefined;
   };

--- a/src/pages/Diary/components/DiaryMain/DiaryRecordsPreviews.tsx
+++ b/src/pages/Diary/components/DiaryMain/DiaryRecordsPreviews.tsx
@@ -21,7 +21,7 @@ const DiaryRecordsPreviews = () => {
     <div>
       <div className="grid grid-cols-3 md:grid-cols-2">
         {diarys.content.map((diary) => (
-          <div className="m-2">
+          <div className="m-2" key={diary.diaryId}>
             <DiaryPreviewItem
               key={diary.diaryId}
               date={diary.datingDay}

--- a/src/pages/Diary/components/DiaryMap/DiaryMapMarker.tsx
+++ b/src/pages/Diary/components/DiaryMap/DiaryMapMarker.tsx
@@ -2,7 +2,6 @@ import { MapMarker } from 'react-kakao-maps-sdk';
 import { UserPosition } from '~/types';
 import useDiary from '~/pages/Diary/hooks/Diary/useDiary';
 import useDiaryToMarker from '~/pages/Diary/hooks/Diary/useDiarytoMarker';
-
 import useDiaryMap from '~/pages/Diary/hooks/DiaryMap/useDiaryMap';
 import useGetDiarys from '~/services/diary/useGetDiarys';
 
@@ -20,6 +19,7 @@ const DiaryMapMarker = ({ userPosition }: UserPosition) => {
   const diaryMarkers = useDiaryToMarker({ diarys });
   const { yetMarkers, goneMarkers } = useDiaryMap();
 
+  console.log(diaryMarkers, yetMarkers, goneMarkers);
   if (!userPosition || !isSuccess || !diarys) return;
 
   return (

--- a/src/pages/Diary/components/DiaryMap/DiaryMapMarker.tsx
+++ b/src/pages/Diary/components/DiaryMap/DiaryMapMarker.tsx
@@ -19,7 +19,6 @@ const DiaryMapMarker = ({ userPosition }: UserPosition) => {
   const diaryMarkers = useDiaryToMarker({ diarys });
   const { yetMarkers, goneMarkers } = useDiaryMap();
 
-  console.log(diaryMarkers, yetMarkers, goneMarkers);
   if (!userPosition || !isSuccess || !diarys) return;
 
   return (

--- a/src/pages/Diary/components/DiarySpot/DiarySpotPreview.tsx
+++ b/src/pages/Diary/components/DiarySpot/DiarySpotPreview.tsx
@@ -1,3 +1,4 @@
+import { useRef, useEffect } from 'react';
 import useDiarySpotContext from '../../hooks/useDiarySpotContext';
 import { Img } from '~/components/common';
 
@@ -6,23 +7,50 @@ interface DiarySpotPreviewProps {
   id: number;
   date: string;
   onClick: () => void;
+  isChecked: boolean;
 }
 
 const DiarySpotPreview = ({
   picture,
   id,
   date,
-  onClick,
+  isChecked,
 }: DiarySpotPreviewProps) => {
   const diarySpotContext = useDiarySpotContext();
-  const { deleteMode } = diarySpotContext;
+  const checkboxRef = useRef<HTMLInputElement>(null);
+  const { deleteMode, handleCheckboxChange } = diarySpotContext;
+
+  const checkboxChange = (id: number) => {
+    if (checkboxRef.current) {
+      handleCheckboxChange(id, checkboxRef.current.checked);
+    }
+  };
+
+  const handleDivClick = (
+    event: React.MouseEvent<HTMLDivElement, MouseEvent>,
+  ) => {
+    if (
+      deleteMode &&
+      checkboxRef.current &&
+      !checkboxRef.current.contains(event.target as Node)
+    ) {
+      checkboxRef.current.click();
+    }
+    handleCheckboxChange(id, !isChecked); // 체크박스 상태 변경
+  };
+
+  useEffect(() => {
+    if (checkboxRef.current) {
+      checkboxRef.current.checked = isChecked;
+    }
+  }, [isChecked]);
 
   return (
     <div
       key={id}
       id={`item_${id}`}
       className="group flex cursor-pointer flex-col items-center justify-center rounded-xl border border-grey-200"
-      onClick={onClick}
+      onClick={handleDivClick}
     >
       <div className="h-32 ">
         <Img
@@ -33,9 +61,12 @@ const DiarySpotPreview = ({
         />
         {deleteMode && (
           <input
+            ref={checkboxRef}
             type="checkbox"
             id={`item${id}`}
             className="checkbox-error checkbox relative -top-[95%] left-2 flex h-4 w-4 bg-base-white"
+            checked={isChecked}
+            onChange={() => checkboxChange(id)}
           />
         )}
       </div>

--- a/src/pages/Diary/components/DiarySpot/DiarySpotPreviews.tsx
+++ b/src/pages/Diary/components/DiarySpot/DiarySpotPreviews.tsx
@@ -2,6 +2,7 @@ import { useLocation, useNavigate } from 'react-router-dom';
 import { SpotDiaries } from '~/types';
 import DiarySpotPreview from './DiarySpotPreview';
 import DiaryCreateButton from '~/pages/Diary/components/DiarySpot/DiaryCreateButton';
+import useDiarySpotContext from '~/pages/Diary/hooks/useDiarySpotContext';
 
 interface DiarySpotPreviewsProps {
   spotDiaries: SpotDiaries;
@@ -10,6 +11,8 @@ interface DiarySpotPreviewsProps {
 const DiarySpotPreviews = ({ spotDiaries }: DiarySpotPreviewsProps) => {
   const { pathname } = useLocation();
   const navigate = useNavigate();
+  const diarySpotContext = useDiarySpotContext();
+  const { deleteMode, selectedIds } = diarySpotContext;
 
   return (
     <div className="flex flex-col items-center justify-center gap-4">
@@ -20,7 +23,12 @@ const DiarySpotPreviews = ({ spotDiaries }: DiarySpotPreviewsProps) => {
           picture={diary.imageUrl}
           id={diary.diaryId}
           date={diary.datingDay}
-          onClick={() => navigate(`${pathname}/${diary.diaryId}`)}
+          onClick={
+            deleteMode
+              ? () => {}
+              : () => navigate(`${pathname}/${diary.diaryId}`)
+          }
+          isChecked={selectedIds.includes(diary.diaryId)}
         />
       ))}
     </div>

--- a/src/pages/Diary/contexts/DiaryContext.tsx
+++ b/src/pages/Diary/contexts/DiaryContext.tsx
@@ -26,6 +26,8 @@ export interface DiaryContextProps {
   setSideBarToggle: React.Dispatch<React.SetStateAction<boolean>>;
   markers: MapMarker[];
   setMarkers: React.Dispatch<React.SetStateAction<MapMarker[]>>;
+  diaryMarkers: MapMarker[];
+  setDiaryMarkers: React.Dispatch<React.SetStateAction<MapMarker[]>>;
   diaryCategory: categoryType | undefined;
   setDiaryCategory: React.Dispatch<
     React.SetStateAction<categoryType | undefined>
@@ -63,6 +65,7 @@ const DiaryProvider = ({ children }: PropsWithChildren) => {
   const [searchMode, setSearchMode] = useState(false);
   const [sideBarToggle, setSideBarToggle] = useState(true);
   const [markers, setMarkers] = useState<MapMarker[]>([]);
+  const [diaryMarkers, setDiaryMarkers] = useState<MapMarker[]>([]);
   const [diaryCategory, setDiaryCategory] = useState<categoryType | undefined>(
     undefined,
   );
@@ -122,6 +125,8 @@ const DiaryProvider = ({ children }: PropsWithChildren) => {
         setSideBarToggle,
         markers,
         setMarkers,
+        diaryMarkers,
+        setDiaryMarkers,
         diaryCategory,
         setDiaryCategory,
         selectSortMethod,

--- a/src/pages/Diary/contexts/DiarySpotContext.tsx
+++ b/src/pages/Diary/contexts/DiarySpotContext.tsx
@@ -2,12 +2,16 @@ import { PropsWithChildren, createContext, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { SpotDiaries } from '~/types';
 import useDiaryContext from '../hooks/useDiaryContext';
+import useDeleteDiaryDetail from '~/services/diary/useDeleteDiaryDetail';
 import useGetSpotDiarys from '~/services/diary/useGetSpotDiarys';
 
 interface DiarySpotContextProps {
   deleteMode: boolean;
   spotDiaries: SpotDiaries;
+  selectedIds: number[];
   handleDeleteMode: () => void;
+  handleCheckboxChange: (id: number, isChecked: boolean) => void;
+  handleDeleteDiary: () => void;
 }
 
 export const DiarySpotContext = createContext<DiarySpotContextProps | null>(
@@ -17,23 +21,57 @@ export const DiarySpotContext = createContext<DiarySpotContextProps | null>(
 const DiarySpotProvider = ({ children }: PropsWithChildren) => {
   const { info } = useDiaryContext();
   const params = useParams();
+  const [selectedIds, setSelectedIds] = useState<number[]>([]);
+  const [deleteMode, setDeleteMode] = useState(false);
+  const { mutate: deleteMutate } = useDeleteDiaryDetail(params.spotId);
 
   if (info === undefined || info.spotId !== params.spotId) {
     throw new Error('앗! 유효하지 않은 접근이에요!');
   }
 
-  const [deleteMode, setDeleteMode] = useState(false);
   const { data: spotDiaries } = useGetSpotDiarys({
     kakaoMapId: Number(info.spotId),
   });
 
+  const handleCheckboxChange = (id: number, isChecked: boolean) => {
+    setSelectedIds((prevSelectedIds) => {
+      const newSelectedIds = new Set(prevSelectedIds);
+
+      if (isChecked) {
+        newSelectedIds.add(id);
+      } else {
+        newSelectedIds.delete(id);
+      }
+
+      return Array.from(newSelectedIds);
+    });
+  };
+
+  const handleDeleteDiary = () => {
+    const { spotId } = params;
+
+    console.log(selectedIds);
+    if (spotId) {
+      deleteMutate({ diaryList: selectedIds });
+      setSelectedIds([]);
+    }
+  };
+
   const handleDeleteMode = () => {
+    if (deleteMode) handleDeleteDiary();
     setDeleteMode(!deleteMode);
   };
 
   return (
     <DiarySpotContext.Provider
-      value={{ deleteMode, spotDiaries, handleDeleteMode }}
+      value={{
+        deleteMode,
+        spotDiaries,
+        handleDeleteMode,
+        selectedIds,
+        handleCheckboxChange,
+        handleDeleteDiary,
+      }}
     >
       {children}
     </DiarySpotContext.Provider>

--- a/src/pages/Diary/hooks/Diary/useDiarytoMarker.ts
+++ b/src/pages/Diary/hooks/Diary/useDiarytoMarker.ts
@@ -1,10 +1,13 @@
 import { Diarys } from '~/types';
+// import useDiary from '~/pages/Diary/hooks/Diary/useDiary';
 
 interface useDiaryToMarkerProps {
   diarys: Diarys | undefined;
 }
 
 const useDiaryToMarker = ({ diarys }: useDiaryToMarkerProps) => {
+  // const { diaryMarkers, setDiaryMarkers } = useDiary();
+
   if (!diarys) return;
 
   const markers = [];
@@ -22,6 +25,8 @@ const useDiaryToMarker = ({ diarys }: useDiaryToMarkerProps) => {
 
     markers.push(info);
   }
+
+  // setDiaryMarkers(markers);
 
   return markers;
 };

--- a/src/pages/Diary/hooks/Diary/useFilterMarker.ts
+++ b/src/pages/Diary/hooks/Diary/useFilterMarker.ts
@@ -2,6 +2,7 @@ import { useEffect } from 'react';
 import { MarkerFilter } from '~/pages/Diary/contexts/DiaryMapContext';
 import useDiary from '~/pages/Diary/hooks/Diary/useDiary';
 import useDiaryMap from '~/pages/Diary/hooks/DiaryMap/useDiaryMap';
+import useGetDiarys from '~/services/diary/useGetDiarys';
 
 const useFilterMarker = () => {
   const {
@@ -12,9 +13,12 @@ const useFilterMarker = () => {
     yetMarkers,
     setYetMarkers,
   } = useDiaryMap();
-  const { markers, diarys } = useDiary();
+  const { markers } = useDiary();
+  const { data: diarys, isSuccess } = useGetDiarys();
 
   const handleFilterMarker = () => {
+    if (!isSuccess) return;
+
     const diaryContent = diarys.content;
 
     const gone = markers.filter((marker) => {
@@ -60,7 +64,7 @@ const useFilterMarker = () => {
 
   useEffect(() => {
     handleFilterMarker();
-  }, [markerFilter, markers]);
+  }, [markerFilter, markers, diarys]);
 
   return {
     markerFilter,

--- a/src/pages/Diary/hooks/Diary/useMapLocation.ts
+++ b/src/pages/Diary/hooks/Diary/useMapLocation.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import { MapMarker } from '~/types';
 import { DiaryContextProps } from '~/pages/Diary/contexts/DiaryContext';
 

--- a/src/pages/Diary/hooks/DiaryContent/useDiaryContent.ts
+++ b/src/pages/Diary/hooks/DiaryContent/useDiaryContent.ts
@@ -46,7 +46,9 @@ const useDiaryContent = ({
     const { diaryId } = params;
 
     if (diaryId) {
-      deleteMutate({ diaryId });
+      const diaryList = [parseInt(diaryId)];
+
+      deleteMutate({ diaryList: diaryList });
     }
   };
 

--- a/src/router/PrivateRouter.tsx
+++ b/src/router/PrivateRouter.tsx
@@ -4,7 +4,7 @@ import checkParams from '~/utils/checkParams';
 
 /** @todo: 유저가 localStorage 토큰 값을 수정하는 경우 checkAuth 등으로 에러 표시 필요 */
 const PrivateRouter = () => {
-  const token = checkParams('token');
+  const token = checkParams('accessToken');
   const { isLoggedIn } = useLogin(token);
 
   return isLoggedIn() ? <Outlet /> : <Navigate to={`login`} replace />;

--- a/src/services/diary/useCreateDiaryDetail.ts
+++ b/src/services/diary/useCreateDiaryDetail.ts
@@ -1,4 +1,8 @@
-import { useMutation } from '@tanstack/react-query';
+import {
+  InvalidateQueryFilters,
+  useMutation,
+  useQueryClient,
+} from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
 import apiClient from '~/api/apiClient';
 
@@ -17,15 +21,30 @@ const createDiaryDetail = async ({ formData }: CreateDiaryDetailParams) => {
 
 const useCreateDiaryDetail = (kakaoMapId: string) => {
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
 
-  return useMutation({
+  const mutation = useMutation({
     mutationKey: ['diaryEdit'],
     mutationFn: ({ formData }: CreateDiaryDetailParams) =>
       createDiaryDetail({ formData }),
-    onSuccess: () => {
-      navigate(`/diary/${kakaoMapId}`);
+    onSuccess: async () => {
+      try {
+        await queryClient.invalidateQueries([
+          'Diarys',
+          'createdDate',
+        ] as InvalidateQueryFilters);
+        // await queryClient.refetchQueries([
+        //   'Diarys',
+        //   'createdDate',
+        // ] as InvalidateQueryFilters);
+        navigate(`/diary/${kakaoMapId}`);
+      } catch (error) {
+        console.error('An error occurred while invalidating queries:', error);
+      }
     },
   });
+
+  return mutation;
 };
 
 export default useCreateDiaryDetail;

--- a/src/services/diary/useDeleteDiaryDetail.ts
+++ b/src/services/diary/useDeleteDiaryDetail.ts
@@ -1,4 +1,8 @@
-import { useMutation, useQueryClient } from '@tanstack/react-query';
+import {
+  InvalidateQueryFilters,
+  useMutation,
+  useQueryClient,
+} from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
 import apiClient from '~/api/apiClient';
 
@@ -13,7 +17,7 @@ const deleteDiaryDetail = async ({ diaryList }: DeleteDiaryDetailParams) => {
   return response.data;
 };
 
-const useDeleteDiaryDetail = (kakaoMapId: string) => {
+const useDeleteDiaryDetail = (kakaoMapId: string | undefined) => {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
 
@@ -22,9 +26,10 @@ const useDeleteDiaryDetail = (kakaoMapId: string) => {
     mutationFn: ({ diaryList }: DeleteDiaryDetailParams) =>
       deleteDiaryDetail({ diaryList }),
     onSuccess: async () => {
-      await queryClient.invalidateQueries({
-        queryKey: ['Diarys', 'createdDate'],
-      });
+      await queryClient.invalidateQueries([
+        ['Diarys', 'createdDate'],
+        ['Diarys', kakaoMapId],
+      ] as InvalidateQueryFilters);
       navigate(`/diary/${kakaoMapId}`);
     },
   });

--- a/src/services/diary/useDeleteDiaryDetail.ts
+++ b/src/services/diary/useDeleteDiaryDetail.ts
@@ -1,26 +1,30 @@
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
 import apiClient from '~/api/apiClient';
 
 interface DeleteDiaryDetailParams {
-  diaryId: string | number;
+  diaryList: number[];
 }
 
-const deleteDiaryDetail = async ({ diaryId }: DeleteDiaryDetailParams) => {
-  const url = `/diaries/${diaryId}`;
-  const response = await apiClient.delete(url);
+const deleteDiaryDetail = async ({ diaryList }: DeleteDiaryDetailParams) => {
+  const url = `/diaries/delete`;
+  const response = await apiClient.post(url, { diaryList });
 
   return response.data;
 };
 
 const useDeleteDiaryDetail = (kakaoMapId: string) => {
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
 
   return useMutation({
     mutationKey: ['diaryEdit'],
-    mutationFn: ({ diaryId }: DeleteDiaryDetailParams) =>
-      deleteDiaryDetail({ diaryId }),
-    onSuccess: () => {
+    mutationFn: ({ diaryList }: DeleteDiaryDetailParams) =>
+      deleteDiaryDetail({ diaryList }),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: ['Diarys', 'createdDate'],
+      });
       navigate(`/diary/${kakaoMapId}`);
     },
   });

--- a/src/services/diary/useGetDiarys.ts
+++ b/src/services/diary/useGetDiarys.ts
@@ -11,7 +11,7 @@ const getDiarys = async ({
   selectSortMethod = 'createdDate',
   diaryCategory,
 }: getDiarysParams): Promise<Diarys> => {
-  let apiUrl = `/diaries?page=0&size=10&sort=${selectSortMethod}`;
+  let apiUrl = `/diaries?page=0&size=10&sort=${selectSortMethod},desc`;
 
   if (diaryCategory) {
     apiUrl += `&category=${diaryCategory}`;


### PR DESCRIPTION
# 🔨 개발 사항 | 변경 사항
다이어리 spot 부분의 다중 삭제 api를 연동하고 기존 삭제 로직을 id값이 아닌 id 배열을 받도록 수정했습니다.
검색 로직을 변경했습니다. (기존 15개에서 -> 45개 받도록)
다이어리 생성, 삭제시 마커가 즉시 반영되도록 수정했습니다.

### 개발 사항
<!-- 커밋 단위로 잘게 나누어서 작성합시다! 개발사항1, 개발사항2... 등등 -->
- [x] 다중 삭제 연동
- [x] 삭제 로직 변경
- [x] 검색 로직 변경
- [x] 생성, 삭제시 마커 즉시 변경


# 🚨 이슈번호

- close #134 