### PR TITLE
 🚨Fix: 무한 스크롤 에러 수정

### DIFF
--- a/src/pages/Diary/Diary.tsx
+++ b/src/pages/Diary/Diary.tsx
@@ -1,25 +1,21 @@
-import * as React from 'react';
 import { Outlet } from 'react-router-dom';
 import { DiarySideBar } from './components/DiaryCommon';
-import DiaryLoading from './DiaryLoading';
 import DiaryMap from '~/pages/Diary/components/DiaryMap/DiaryMap';
 import { DiaryProvider } from '~/pages/Diary/contexts/DiaryContext';
 import { DiaryMapProvider } from '~/pages/Diary/contexts/DiaryMapContext';
 
 const Diary = () => {
   return (
-    <React.Suspense fallback={<DiaryLoading />}>
-      <DiaryProvider>
-        <div className="h-full w-full">
-          <DiarySideBar>
-            <Outlet />
-          </DiarySideBar>
-          <DiaryMapProvider>
-            <DiaryMap />
-          </DiaryMapProvider>
-        </div>
-      </DiaryProvider>
-    </React.Suspense>
+    <DiaryProvider>
+      <div className="h-full w-full">
+        <DiarySideBar>
+          <Outlet />
+        </DiarySideBar>
+        <DiaryMapProvider>
+          <DiaryMap />
+        </DiaryMapProvider>
+      </div>
+    </DiaryProvider>
   );
 };
 

--- a/src/pages/Diary/components/DiaryMain/DiaryRecordsPreviews.tsx
+++ b/src/pages/Diary/components/DiaryMain/DiaryRecordsPreviews.tsx
@@ -4,9 +4,9 @@ import { DiaryPreviewItem } from '~/components/domain';
 
 const DiaryRecordsPreviews = () => {
   const {
-    diarys,
     methods: { handleClickPreviews },
   } = useDiaryContext();
+  const { diarys } = useDiaryMainContext();
   const { recordRef } = useDiaryMainContext();
   const { handleClickPreview } = handleClickPreviews;
 

--- a/src/pages/Diary/components/DiaryMain/DiaryRecordsPreviews.tsx
+++ b/src/pages/Diary/components/DiaryMain/DiaryRecordsPreviews.tsx
@@ -19,7 +19,7 @@ const DiaryRecordsPreviews = () => {
             ref={diarys.length - 1 === index ? recordRef : null}
           >
             <DiaryPreviewItem
-              key={diary.diaryId}
+              key={`${diary.diaryId}-${index}`}
               date={diary.datingDay}
               location={diary.placeName}
               imgSrc={diary.imageUrl}

--- a/src/pages/Diary/components/DiaryMap/DiaryMapMarker.tsx
+++ b/src/pages/Diary/components/DiaryMap/DiaryMapMarker.tsx
@@ -7,7 +7,7 @@ import useDiaryMap from '~/pages/Diary/hooks/DiaryMap/useDiaryMap';
 /** @todo: 추후 내 위치 마커와 장소 표시 마커 분리시키기 */
 const DiaryMapMarker = ({ userPosition }: UserPosition) => {
   const {
-    diarys,
+    rootDiarys,
     searchKeyword,
     markers,
     methods: { handleMarkers, handleSearch },
@@ -15,7 +15,7 @@ const DiaryMapMarker = ({ userPosition }: UserPosition) => {
   const { useSearchLocation } = handleSearch;
   useSearchLocation(searchKeyword);
   const { handleMarker } = handleMarkers;
-  const diaryMarkers = useDiaryToMarker({ diarys });
+  const diaryMarkers = useDiaryToMarker({ rootDiarys });
   const { yetMarkers, goneMarkers } = useDiaryMap();
 
   return (

--- a/src/pages/Diary/components/DiaryMap/DiaryMapMarker.tsx
+++ b/src/pages/Diary/components/DiaryMap/DiaryMapMarker.tsx
@@ -33,9 +33,9 @@ const DiaryMapMarker = ({ userPosition }: UserPosition) => {
       />
       {/* 다이어리 목록 마커 */}
       {markers.length ||
-        diaryMarkers?.map((marker) => (
+        diaryMarkers?.map((marker, index) => (
           <MapMarker
-            key={`marker-${marker.content}-${marker.position.lat},${marker.position.lng}`}
+            key={`marker-${marker.content}-${marker.position.lat},${marker.position.lng}-${index}`}
             position={marker.position}
             onClick={() => handleMarker(marker)}
             image={{

--- a/src/pages/Diary/contexts/DiaryContent/DiaryContentContext.tsx
+++ b/src/pages/Diary/contexts/DiaryContent/DiaryContentContext.tsx
@@ -64,10 +64,6 @@ const DiaryContentProvider = ({ mode, children }: DiaryContentProvider) => {
     setExistedImg(imgURL);
   }, [originDiary]);
 
-  useEffect(() => {
-    console.log(imgUrl);
-  }, [imgUrl]);
-
   return (
     <DiaryContentContext.Provider
       value={{

--- a/src/pages/Diary/contexts/DiaryContext.tsx
+++ b/src/pages/Diary/contexts/DiaryContext.tsx
@@ -12,7 +12,6 @@ import useMapCategory from '~/pages/Diary/hooks/Diary/useMapCategory';
 import useSearch from '~/pages/Diary/hooks/Diary/useMapLocation';
 import useSelectSortMethod from '~/pages/Diary/hooks/Diary/useSelectSortMethod';
 import useSideBar from '~/pages/Diary/hooks/Diary/useSideBar';
-import useGetDiarys from '~/services/diary/useGetDiarys';
 
 export interface DiaryContextProps {
   searchKeyword: string;
@@ -29,8 +28,6 @@ export interface DiaryContextProps {
   setDiaryCategory: React.Dispatch<
     React.SetStateAction<categoryType | undefined>
   >;
-  page: number;
-  setPage: React.Dispatch<React.SetStateAction<number>>;
   selectSortMethod: string;
   setSelectSortMethod: React.Dispatch<React.SetStateAction<string>>;
   info: MapMarker | undefined;
@@ -39,7 +36,8 @@ export interface DiaryContextProps {
   setInfoOpen: React.Dispatch<React.SetStateAction<boolean>>;
   map: kakao.maps.Map | undefined;
   setMap: React.Dispatch<React.SetStateAction<kakao.maps.Map | undefined>>;
-  diarys: DiaryContent[];
+  rootDiarys: DiaryContent[];
+  setRootDiarys: React.Dispatch<React.SetStateAction<DiaryContent[]>>;
   mapCategory: categoryType | undefined;
   setMapCategory: React.Dispatch<
     React.SetStateAction<categoryType | undefined>
@@ -79,21 +77,7 @@ const DiaryProvider = ({ children }: PropsWithChildren) => {
   const [mapCategory, setMapCategory] = useState<categoryType | undefined>(
     undefined,
   );
-  const [page, setPage] = useState(0);
-  const { data: diaryResponse } = useGetDiarys({ page, diaryCategory });
-  const [diarys, setDiarys] = useState<DiaryContent[]>([]);
-
-  useEffect(() => {
-    setPage(0);
-  }, [diaryCategory]);
-
-  useEffect(() => {
-    if (page === 0) {
-      setDiarys(diaryResponse.content);
-    } else {
-      setDiarys([...diarys, ...diaryResponse.content]);
-    }
-  }, [diaryResponse]);
+  const [rootDiarys, setRootDiarys] = useState<DiaryContent[]>([]);
 
   const handleInfo = useInfoToggle({ infoOpen, setInfoOpen, setInfo });
   const handleSideBar = useSideBar({ sideBarToggle, setSideBarToggle });
@@ -139,8 +123,6 @@ const DiaryProvider = ({ children }: PropsWithChildren) => {
         setSearchMode,
         sideBarToggle,
         setSideBarToggle,
-        page,
-        setPage,
         markers,
         setMarkers,
         diaryMarkers,
@@ -155,7 +137,8 @@ const DiaryProvider = ({ children }: PropsWithChildren) => {
         setInfoOpen,
         map,
         setMap,
-        diarys,
+        rootDiarys,
+        setRootDiarys,
         mapCategory,
         setMapCategory,
 

--- a/src/pages/Diary/contexts/DiaryContext.tsx
+++ b/src/pages/Diary/contexts/DiaryContext.tsx
@@ -84,7 +84,6 @@ const DiaryProvider = ({ children }: PropsWithChildren) => {
   const [diarys, setDiarys] = useState<DiaryContent[]>([]);
 
   useEffect(() => {
-    setDiarys([]);
     setPage(0);
   }, [diaryCategory]);
 

--- a/src/pages/Diary/contexts/DiaryContext.tsx
+++ b/src/pages/Diary/contexts/DiaryContext.tsx
@@ -89,7 +89,11 @@ const DiaryProvider = ({ children }: PropsWithChildren) => {
   }, [diaryCategory]);
 
   useEffect(() => {
-    setDiarys((prevPost) => [...prevPost, ...diaryResponse.content]);
+    if (page === 0) {
+      setDiarys(diaryResponse.content);
+    } else {
+      setDiarys([...diarys, ...diaryResponse.content]);
+    }
   }, [diaryResponse]);
 
   const handleInfo = useInfoToggle({ infoOpen, setInfoOpen, setInfo });

--- a/src/pages/Diary/contexts/DiaryMainContext.tsx
+++ b/src/pages/Diary/contexts/DiaryMainContext.tsx
@@ -1,21 +1,51 @@
-import { LegacyRef, PropsWithChildren, createContext, useState } from 'react';
+import {
+  LegacyRef,
+  PropsWithChildren,
+  createContext,
+  useEffect,
+  useState,
+} from 'react';
+import type { DiaryContent } from '~/types';
+import useDiaryContext from '../hooks/Diary/useDiaryContext';
 import useDiaryMainObserver from '../hooks/DiaryMain/useDiaryMainObserver';
+import useGetDiarys from '~/services/diary/useGetDiarys';
 
 interface DiaryMainContextProps {
   selectCategory: string;
   setSelectCategory: React.Dispatch<React.SetStateAction<string>>;
   recordRef: LegacyRef<HTMLDivElement> | undefined;
+  diarys: DiaryContent[];
 }
 
 const DiaryMainContext = createContext<DiaryMainContextProps | null>(null);
 
 const DiaryMainProvider = ({ children }: PropsWithChildren) => {
+  const { diaryCategory, setRootDiarys } = useDiaryContext();
   const [selectCategory, setSelectCategory] = useState('');
-  const { recordRef } = useDiaryMainObserver();
+  const [page, setPage] = useState(0);
+  const [diarys, setDiarys] = useState<DiaryContent[]>([]);
+  const { data: diaryResponse } = useGetDiarys({ page, diaryCategory });
+  const { recordRef } = useDiaryMainObserver({ page, setPage, diarys });
+
+  useEffect(() => {
+    setPage(0);
+  }, [diaryCategory]);
+
+  useEffect(() => {
+    if (page === 0) {
+      setDiarys(diaryResponse.content);
+    } else {
+      setDiarys([...diarys, ...diaryResponse.content]);
+    }
+  }, [diaryResponse]);
+
+  useEffect(() => {
+    setRootDiarys(diarys);
+  }, [diarys]);
 
   return (
     <DiaryMainContext.Provider
-      value={{ selectCategory, setSelectCategory, recordRef }}
+      value={{ selectCategory, setSelectCategory, recordRef, diarys }}
     >
       {children}
     </DiaryMainContext.Provider>

--- a/src/pages/Diary/hooks/Diary/useDiarytoMarker.ts
+++ b/src/pages/Diary/hooks/Diary/useDiarytoMarker.ts
@@ -1,16 +1,15 @@
-
 import type { DiaryContent } from '~/types';
 
 interface useDiaryToMarkerProps {
-  diarys: DiaryContent[] | undefined;
+  rootDiarys: DiaryContent[] | undefined;
 }
 
-const useDiaryToMarker = ({ diarys }: useDiaryToMarkerProps) => {
-  if (!diarys) return;
+const useDiaryToMarker = ({ rootDiarys }: useDiaryToMarkerProps) => {
+  if (!rootDiarys) return;
 
   const markers = [];
 
-  for (const diary of diarys) {
+  for (const diary of rootDiarys) {
     const info = {
       position: {
         lat: diary.latitude,

--- a/src/pages/Diary/hooks/Diary/useFilterMarker.ts
+++ b/src/pages/Diary/hooks/Diary/useFilterMarker.ts
@@ -12,10 +12,10 @@ const useFilterMarker = () => {
     yetMarkers,
     setYetMarkers,
   } = useDiaryMap();
-  const { markers, diarys } = useDiaryContext();
+  const { markers, rootDiarys } = useDiaryContext();
 
   const handleFilterMarker = () => {
-    const diaryContent = diarys;
+    const diaryContent = rootDiarys;
     const gone = markers.filter((marker) => {
       return diaryContent.find(
         (diaryContent) => diaryContent.kakaoMapId === Number(marker.spotId),
@@ -58,7 +58,7 @@ const useFilterMarker = () => {
   };
   useEffect(() => {
     handleFilterMarker();
-  }, [markerFilter, markers, diarys]);
+  }, [markerFilter, markers, rootDiarys]);
 
   return {
     markerFilter,

--- a/src/pages/Diary/hooks/DiaryMain/useDiaryMainObserver.ts
+++ b/src/pages/Diary/hooks/DiaryMain/useDiaryMainObserver.ts
@@ -1,9 +1,18 @@
 import { useRef, useEffect } from 'react';
+import type { DiaryContent } from '~/types';
 import useObserve from '~/hooks/useObserve';
-import useDiaryContext from '~/pages/Diary/hooks/Diary/useDiaryContext';
 
-const useDiaryMainObserver = () => {
-  const { diarys, page, setPage } = useDiaryContext();
+interface useDiaryMainObserverProps {
+  page: number;
+  setPage: React.Dispatch<React.SetStateAction<number>>;
+  diarys: DiaryContent[];
+}
+
+const useDiaryMainObserver = ({
+  page,
+  setPage,
+  diarys,
+}: useDiaryMainObserverProps) => {
   const [observe] = useObserve(() => {
     setPage(page + 1);
   });


### PR DESCRIPTION
# 🔨 개발 사항 | 변경 사항

### 무한 스크롤 데이터가 중복으로 불러와지는 문제

- 페이지가 0 이면 dataResponse 값을 넣어주고, 페이지가 0 이상이면 기존의 데이터에 추가로 dataResponse 값을 넣어줘요.

### 로딩 시 화면 전체가 깜빡이는 문제 수정

- 최상위 context 에서 다이어리 데이터를 관리하고 있던 것을 DiaryMain 으로 옮겼어요.
- 최상위 context 에선 diarys 대신 rootDiarys 를 사용하여 마커를 표시할 수 있어요.
- 이제 로딩 시 사이드 바에만 로딩 컴포넌트가 나타나요.

# 📝 리뷰어들이 보면 좋을 사항

# 🚨 이슈번호
