### PR TITLE
✨ Feat: 다이어리 수정 API 반영

### DIFF
--- a/src/pages/Diary/components/DiaryMain/DiaryMain.tsx
+++ b/src/pages/Diary/components/DiaryMain/DiaryMain.tsx
@@ -1,19 +1,16 @@
 import DiaryRecords from './DiaryRecords';
 import DiarySearchBar from './DiarySearchBar';
 import DiarySearchResults from '~/pages/Diary/components/DiaryMain/DiarySearchResults';
-import { DiaryMainProvider } from '~/pages/Diary/contexts/DiaryMainContext';
 import useDiaryContext from '~/pages/Diary/hooks/Diary/useDiaryContext';
 
 const DiaryMain = () => {
   const { searchMode } = useDiaryContext();
 
   return (
-    <DiaryMainProvider>
-      <div className="flex w-full flex-col gap-10 overflow-y-auto overflow-x-hidden">
-        <DiarySearchBar />
-        {searchMode ? <DiarySearchResults /> : <DiaryRecords />}
-      </div>
-    </DiaryMainProvider>
+    <div className="flex w-full flex-col gap-10 overflow-y-auto overflow-x-hidden">
+      <DiarySearchBar />
+      {searchMode ? <DiarySearchResults /> : <DiaryRecords />}
+    </div>
   );
 };
 

--- a/src/pages/Diary/components/DiaryMain/DiaryMain.tsx
+++ b/src/pages/Diary/components/DiaryMain/DiaryMain.tsx
@@ -1,3 +1,4 @@
+import { DiaryMainProvider } from '../../contexts/DiaryMainContext';
 import DiaryRecords from './DiaryRecords';
 import DiarySearchBar from './DiarySearchBar';
 import DiarySearchResults from '~/pages/Diary/components/DiaryMain/DiarySearchResults';

--- a/src/pages/Diary/components/DiaryMain/DiaryMainLoadingFallback.tsx
+++ b/src/pages/Diary/components/DiaryMain/DiaryMainLoadingFallback.tsx
@@ -1,0 +1,11 @@
+import { Loading } from '~/components/common';
+
+const DiaryMainLoadingFallback = () => {
+  return (
+    <div className="flex h-full w-full items-center justify-center">
+      <Loading size={'large'} />
+    </div>
+  );
+};
+
+export default DiaryMainLoadingFallback;

--- a/src/pages/Diary/components/DiaryMain/DiaryRecords.tsx
+++ b/src/pages/Diary/components/DiaryMain/DiaryRecords.tsx
@@ -1,6 +1,9 @@
+import { Suspense } from 'react';
+import DiaryMainLoadingFallback from './DiaryMainLoadingFallback';
 import DiaryRecordsHeader from './DiaryRecordsHeader';
 import DiaryRecordsPreviews from './DiaryRecordsPreviews';
 import CategoryList from '~/components/domain/CategoryList/CategoryList';
+import { DiaryMainProvider } from '~/pages/Diary/contexts/DiaryMainContext';
 import useDiaryContext from '~/pages/Diary/hooks/Diary/useDiaryContext';
 
 const DiaryRecords = () => {
@@ -11,14 +14,18 @@ const DiaryRecords = () => {
   const { handleCategory } = handleDiaryCategories;
 
   return (
-    <div className="flex flex-col gap-5">
+    <div className="flex h-full flex-col gap-5">
       <DiaryRecordsHeader />
       <CategoryList
         handleChangeCategory={handleCategory}
         editable={true}
         selectedCategory={diaryCategory}
       />
-      <DiaryRecordsPreviews />
+      <Suspense fallback={<DiaryMainLoadingFallback />}>
+        <DiaryMainProvider>
+          <DiaryRecordsPreviews />
+        </DiaryMainProvider>
+      </Suspense>
     </div>
   );
 };

--- a/src/pages/Diary/components/DiaryMain/DiaryRecords.tsx
+++ b/src/pages/Diary/components/DiaryMain/DiaryRecords.tsx
@@ -1,11 +1,10 @@
 import { Suspense } from 'react';
+import useDiaryMainContext from '../../hooks/DiaryMain/useDiaryMainContext';
 import DiaryMainLoadingFallback from './DiaryMainLoadingFallback';
 import DiaryRecordsHeader from './DiaryRecordsHeader';
 import DiaryRecordsPreviews from './DiaryRecordsPreviews';
 import CategoryList from '~/components/domain/CategoryList/CategoryList';
 import { DiaryMainProvider } from '~/pages/Diary/contexts/DiaryMainContext';
-import useDiaryContext from '~/pages/Diary/hooks/Diary/useDiaryContext';
-import useDiaryMainContext from '../../hooks/DiaryMain/useDiaryMainContext';
 
 const DiaryRecords = () => {
   const diaryMainContext = useDiaryMainContext();

--- a/src/pages/Diary/hooks/DiaryContent/useDiaryContent.ts
+++ b/src/pages/Diary/hooks/DiaryContent/useDiaryContent.ts
@@ -1,7 +1,12 @@
 import type categoryType from '~/components/common/CategoryButton/CategoryTypes';
 import { ChangeEvent, useRef } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
-import type { DiaryResponse, DiaryCreateTextRequest, MapMarker } from '~/types';
+import type {
+  DiaryResponse,
+  DiaryCreateTextRequest,
+  MapMarker,
+  DiaryEditTextRequest,
+} from '~/types';
 import useDiaryContext from '~/pages/Diary/hooks/Diary/useDiaryContext';
 import useCreateDiaryDetail from '~/services/diary/useCreateDiaryDetail';
 import useDeleteDiaryDetail from '~/services/diary/useDeleteDiaryDetail';
@@ -155,13 +160,15 @@ const useDiaryContent = ({
   const handleSubmitEdit = (diaryId: string) => {
     const formData = new FormData();
     const { datingDay, category, myText, score } = editDiary;
-    const texts = {
+    const texts: DiaryEditTextRequest = {
       datingDay,
       category,
       text: myText,
       score,
-      images: existedImg,
     };
+    if (existedImg.length > 0) {
+      texts.images = existedImg;
+    }
     console.log(texts);
     formData.append(
       'texts',

--- a/src/pages/Diary/hooks/DiaryContent/useDiaryContent.ts
+++ b/src/pages/Diary/hooks/DiaryContent/useDiaryContent.ts
@@ -154,12 +154,11 @@ const useDiaryContent = ({
 
   const handleSubmitEdit = (diaryId: string) => {
     const formData = new FormData();
-    const { datingDay, category, myText, opponentText, score } = editDiary;
+    const { datingDay, category, myText, score } = editDiary;
     const texts = {
       datingDay,
       category,
-      myText,
-      opponentText: opponentText === null ? 'ㅎㅇ' : opponentText,
+      text: myText,
       score,
       images: existedImg,
     };

--- a/src/pages/Main/contexts/MainContentContext.tsx
+++ b/src/pages/Main/contexts/MainContentContext.tsx
@@ -7,7 +7,7 @@ import { useCreateTodayQuestion, useGetQuestion } from '~/services/question';
 
 interface MainContentContextProps {
   recentSchedule: CalendarSchedule | undefined;
-  todayQuestion: QuestionForm | undefined;
+  todayQuestion: QuestionFormResponse | undefined;
   recentDiarys: Diarys | undefined;
 }
 

--- a/src/types/diary.ts
+++ b/src/types/diary.ts
@@ -37,9 +37,8 @@ interface DiaryCreateTextRequest extends Diary {
 }
 
 interface DiaryEditTextRequest extends Diary {
-  myText: null | string;
-  opponentText: null | string;
-  images: string[];
+  text: string;
+  images?: string[];
 }
 
 interface DiaryContent {


### PR DESCRIPTION
# 🔨 개발 사항 | 변경 사항

### 다이어리 수정 API 변경된 사항

- 이제 작성과 수정 시 `myText` 와 `opponentText` 대신 본인의 텍스트 값만 넘겨주게 됐어요.
- `text` 프로퍼티를 사용하여 전달해요.
- 서버에서 기존에 내려보내준 이미지가 없다면 `images` 프로퍼티를 넣지 않아요.
- 서버에서 내려준 이미지는 를 `texts` 프로퍼티에 `string[]` 타입으로 추가하고, 사용자가 새로 추가한 이미지 파일은 `images` 프로퍼티에 `File` 타입으로 추가해요.

