### PR TITLE
✨ Feat: 메인 페이지 사진첩 클릭시 지도로 이동하기

### DIFF
--- a/src/pages/Diary/components/DiaryCommon/SideBarFallback.tsx
+++ b/src/pages/Diary/components/DiaryCommon/SideBarFallback.tsx
@@ -4,6 +4,8 @@ import { paths } from '~/router';
 import { Button } from '~/components/common';
 
 const SideBarFallBack = ({ error, resetErrorBoundary }: FallbackProps) => {
+  const { pathname } = location;
+
   return (
     <div className="flex flex-col items-center justify-center">
       <div className="flex flex-col justify-center">
@@ -15,7 +17,12 @@ const SideBarFallBack = ({ error, resetErrorBoundary }: FallbackProps) => {
       <div>
         <Link to={paths.DIARY.ROOT}>
           <Button
-            onClick={resetErrorBoundary}
+            onClick={() => {
+              resetErrorBoundary();
+              if (pathname === paths.DIARY.ROOT) {
+                location.reload();
+              }
+            }}
             size="large"
             className="bg-base-primary text-base-white"
           >

--- a/src/pages/Diary/components/DiaryContent/DiaryContentBody.tsx
+++ b/src/pages/Diary/components/DiaryContent/DiaryContentBody.tsx
@@ -13,7 +13,7 @@ const DiaryContentBody = () => {
 
   return (
     <div className="flex w-full flex-col gap-6 overflow-y-auto overflow-x-hidden">
-      {!editable && <DiaryContentHeader />}
+      <DiaryContentHeader />
       <div
         onSubmit={handleSubmitForm}
         className="flex flex-col gap-6 overflow-y-auto px-3"

--- a/src/pages/Diary/components/DiaryContent/DiaryContentHeader.tsx
+++ b/src/pages/Diary/components/DiaryContent/DiaryContentHeader.tsx
@@ -6,13 +6,11 @@ import useDiaryContext from '~/pages/Diary/hooks/Diary/useDiaryContext';
 
 const DiaryContentHeader = memo(() => {
   const { editable, diary, methods } = useDiaryContentContext();
-  const { kakaoMapId } = diary;
+  const { info } = useDiaryContext();
+  const { kakaoMapId, placeName } = diary;
   const { handleEditMode, handleDeleteDiary } = methods;
   const { DIARY } = paths;
-  const prevLink = `${DIARY.ROOT}/${kakaoMapId}`;
-  const { info } = useDiaryContext();
-
-  if (!info) return;
+  const prevLink = info ? `${DIARY.ROOT}/${kakaoMapId}` : `${DIARY.ROOT}`;
 
   const HeaderButton = () =>
     editable || (
@@ -24,8 +22,8 @@ const DiaryContentHeader = memo(() => {
 
   return (
     <div className="flex items-center justify-between">
-      <DiaryHeader prevLink={prevLink} spotName={info.content} />
-      <HeaderButton />
+      <DiaryHeader prevLink={prevLink} spotName={info?.content || placeName} />
+      {!editable && <HeaderButton />}
     </div>
   );
 });

--- a/src/pages/Diary/components/DiaryMain/DiaryRecords.tsx
+++ b/src/pages/Diary/components/DiaryMain/DiaryRecords.tsx
@@ -1,14 +1,11 @@
+import useDiaryMainContext from '../../hooks/DiaryMain/useDiaryMainContext';
 import DiaryRecordsHeader from './DiaryRecordsHeader';
 import DiaryRecordsPreviews from './DiaryRecordsPreviews';
 import CategoryList from '~/components/domain/CategoryList/CategoryList';
-import useDiaryContext from '~/pages/Diary/hooks/Diary/useDiaryContext';
 
 const DiaryRecords = () => {
-  const {
-    diaryCategory,
-    methods: { handleDiaryCategories },
-  } = useDiaryContext();
-  const { handleCategory } = handleDiaryCategories;
+  const diaryMainContext = useDiaryMainContext();
+  const { handleCategory, diaryCategory } = diaryMainContext;
 
   return (
     <div className="flex flex-col gap-5">

--- a/src/pages/Diary/components/DiaryMain/DiaryRecordsHeader.tsx
+++ b/src/pages/Diary/components/DiaryMain/DiaryRecordsHeader.tsx
@@ -1,10 +1,8 @@
-import useDiaryContext from '~/pages/Diary/hooks/Diary/useDiaryContext';
+import useDiaryMainContext from '../../hooks/DiaryMain/useDiaryMainContext';
 
 const DiaryRecordsHeader = () => {
-  const {
-    methods: { handleSortMethod },
-  } = useDiaryContext();
-  const { handleSortMethodClick } = handleSortMethod;
+  const diaryMainContext = useDiaryMainContext();
+  const { handleSortMethodClick } = diaryMainContext;
 
   return (
     <div className="flex items-center justify-between">

--- a/src/pages/Diary/components/DiaryMain/DiaryRecordsPreviews.tsx
+++ b/src/pages/Diary/components/DiaryMain/DiaryRecordsPreviews.tsx
@@ -8,8 +8,7 @@ const DiaryRecordsPreviews = () => {
   const {
     methods: { handleClickPreviews },
   } = useDiaryContext();
-  const { diarys } = useDiaryMainContext();
-  const { recordRef } = useDiaryMainContext();
+  const { diarys, recordRef } = useDiaryMainContext();
   const { handleClickPreview } = handleClickPreviews;
   const { setMarkerFilter } = useFilterMarker();
 
@@ -23,12 +22,11 @@ const DiaryRecordsPreviews = () => {
       <div className="grid grid-cols-3 md:grid-cols-2">
         {diarys.map((diary, index) => (
           <div
-            key={`${diary.diaryId}`}
+            key={`${diary.diaryId}-${index}`}
             className="m-2"
             ref={diarys.length - 1 === index ? recordRef : null}
           >
             <DiaryPreviewItem
-              key={`${diary.diaryId}`}
               date={diary.datingDay}
               location={diary.placeName}
               imgSrc={diary.imageUrl}

--- a/src/pages/Diary/contexts/DiaryContent/DiaryContentContext.tsx
+++ b/src/pages/Diary/contexts/DiaryContent/DiaryContentContext.tsx
@@ -40,6 +40,8 @@ const DiaryContentProvider = ({ mode, children }: DiaryContentProvider) => {
     },
     kakaoMapId: '',
     placeName: '',
+    latitude: 0,
+    longitude: 0,
   });
   const [existedImg, setExistedImg] = useState<string[]>([]);
   const [imgUrl, setImgUrl] = useState<string[]>([]);

--- a/src/pages/Diary/contexts/DiaryContent/ReadContext.tsx
+++ b/src/pages/Diary/contexts/DiaryContent/ReadContext.tsx
@@ -1,5 +1,7 @@
 import { PropsWithChildren, createContext, useContext, useEffect } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams, useLocation } from 'react-router-dom';
+import type { DiaryContent } from '~/types';
+import useDiaryContext from '../../hooks/Diary/useDiaryContext';
 import { DiaryContentContext } from './DiaryContentContext';
 import useGetDiaryDetail from '~/services/diary/useGetDiaryDetail';
 
@@ -9,8 +11,10 @@ interface ReadProviderProps extends PropsWithChildren {}
 const ReadContext = createContext<null | ReadContextProps>(null);
 
 const ReadProvider = ({ children }: ReadProviderProps) => {
+  const locate = useLocation();
   const params = useParams();
   const { diaryId } = params;
+  const { info, map, setInfo, setRootDiarys, setInfoOpen } = useDiaryContext();
   const { data: diaryResponse } = useGetDiaryDetail({ diaryId });
   const diaryContentContext = useContext(DiaryContentContext);
 
@@ -19,8 +23,38 @@ const ReadProvider = ({ children }: ReadProviderProps) => {
   const { setDiary } = diaryContentContext;
 
   useEffect(() => {
+    const { kakaoMapId, placeName, latitude, longitude } = diaryResponse;
+
     setDiary({ ...diaryResponse });
+
+    if (locate.state) {
+      const diary = locate.state.diary as DiaryContent;
+
+      setInfo({
+        address: diary.address,
+        spotId: String(kakaoMapId),
+        content: placeName,
+        position: {
+          lat: latitude,
+          lng: longitude,
+        },
+      });
+    }
   }, [diaryResponse, setDiary]);
+
+  useEffect(() => {
+    if (locate.state && info) {
+      const diary = locate.state.diary as DiaryContent;
+      const newLatLng = new kakao.maps.LatLng(
+        info.position.lat,
+        info.position.lng,
+      );
+
+      map?.setCenter(newLatLng);
+      setRootDiarys([diary]);
+      setInfoOpen(true);
+    }
+  }, [info, map]);
 
   return <ReadContext.Provider value={{}}>{children}</ReadContext.Provider>;
 };

--- a/src/pages/Diary/contexts/DiaryContent/ReadContext.tsx
+++ b/src/pages/Diary/contexts/DiaryContent/ReadContext.tsx
@@ -40,7 +40,7 @@ const ReadProvider = ({ children }: ReadProviderProps) => {
         },
       });
     }
-  }, [diaryResponse, setDiary]);
+  }, [diaryResponse, setDiary, setInfo, locate.state]);
 
   useEffect(() => {
     if (locate.state && info) {
@@ -54,7 +54,7 @@ const ReadProvider = ({ children }: ReadProviderProps) => {
       setRootDiarys([diary]);
       setInfoOpen(true);
     }
-  }, [info, map]);
+  }, [info, map, setInfoOpen, setRootDiarys, locate.state]);
 
   return <ReadContext.Provider value={{}}>{children}</ReadContext.Provider>;
 };

--- a/src/pages/Diary/contexts/DiaryContext.tsx
+++ b/src/pages/Diary/contexts/DiaryContext.tsx
@@ -1,16 +1,14 @@
-import { PropsWithChildren, createContext, useEffect, useState } from 'react';
+import { PropsWithChildren, createContext, useState } from 'react';
 import { DiaryContent, MapMarker } from '~/types';
 import categoryType from '~/components/common/CategoryButton/CategoryTypes';
 import { DiaryMapProvider } from '~/pages/Diary/contexts/DiaryMapContext';
 import useClickPreview from '~/pages/Diary/hooks/Diary/useClickPreview';
 import useMapLocation from '~/pages/Diary/hooks/Diary/useCurrentLocation';
-import useDiaryCategories from '~/pages/Diary/hooks/Diary/useDiaryCategories';
 import useHandleMarker from '~/pages/Diary/hooks/Diary/useHandleMarker';
 import useInfoToggle from '~/pages/Diary/hooks/Diary/useInfoToggle';
 import useInputRef from '~/pages/Diary/hooks/Diary/useInputRef';
 import useMapCategory from '~/pages/Diary/hooks/Diary/useMapCategory';
 import useSearch from '~/pages/Diary/hooks/Diary/useMapLocation';
-import useSelectSortMethod from '~/pages/Diary/hooks/Diary/useSelectSortMethod';
 import useSideBar from '~/pages/Diary/hooks/Diary/useSideBar';
 
 export interface DiaryContextProps {
@@ -24,12 +22,6 @@ export interface DiaryContextProps {
   setMarkers: React.Dispatch<React.SetStateAction<MapMarker[]>>;
   diaryMarkers: MapMarker[];
   setDiaryMarkers: React.Dispatch<React.SetStateAction<MapMarker[]>>;
-  diaryCategory: categoryType | undefined;
-  setDiaryCategory: React.Dispatch<
-    React.SetStateAction<categoryType | undefined>
-  >;
-  selectSortMethod: string;
-  setSelectSortMethod: React.Dispatch<React.SetStateAction<string>>;
   info: MapMarker | undefined;
   setInfo: React.Dispatch<React.SetStateAction<MapMarker | undefined>>;
   infoOpen: boolean;
@@ -52,8 +44,6 @@ export interface DiaryContextProps {
     handleClickPreviews: ReturnType<typeof useClickPreview>;
     handleLocation: ReturnType<typeof useMapLocation>;
     handleSearch: ReturnType<typeof useSearch>;
-    handleDiaryCategories: ReturnType<typeof useDiaryCategories>;
-    handleSortMethod: ReturnType<typeof useSelectSortMethod>;
   };
 }
 
@@ -65,11 +55,7 @@ const DiaryProvider = ({ children }: PropsWithChildren) => {
   const [sideBarToggle, setSideBarToggle] = useState(true);
   const [markers, setMarkers] = useState<MapMarker[]>([]);
   const [diaryMarkers, setDiaryMarkers] = useState<MapMarker[]>([]);
-  const [diaryCategory, setDiaryCategory] = useState<categoryType | undefined>(
-    undefined,
-  );
-  useEffect(() => {}, [diaryCategory]);
-  const [selectSortMethod, setSelectSortMethod] = useState<string>('datingDay');
+
   const [info, setInfo] = useState<MapMarker>();
   const [infoOpen, setInfoOpen] = useState<boolean>(false);
   const [map, setMap] = useState<kakao.maps.Map>();
@@ -117,8 +103,6 @@ const DiaryProvider = ({ children }: PropsWithChildren) => {
     handleMarkers,
     handleInfo,
   });
-  const handleDiaryCategories = useDiaryCategories({ setDiaryCategory });
-  const handleSortMethod = useSelectSortMethod({ setSelectSortMethod });
 
   return (
     <DiaryContext.Provider
@@ -133,10 +117,6 @@ const DiaryProvider = ({ children }: PropsWithChildren) => {
         setMarkers,
         diaryMarkers,
         setDiaryMarkers,
-        diaryCategory,
-        setDiaryCategory,
-        selectSortMethod,
-        setSelectSortMethod,
         info,
         setInfo,
         infoOpen,
@@ -157,8 +137,6 @@ const DiaryProvider = ({ children }: PropsWithChildren) => {
           handleClickPreviews,
           handleLocation,
           handleSearch,
-          handleDiaryCategories,
-          handleSortMethod,
         },
       }}
     >

--- a/src/pages/Diary/contexts/DiaryMainContext.tsx
+++ b/src/pages/Diary/contexts/DiaryMainContext.tsx
@@ -1,3 +1,4 @@
+import type categoryType from '~/components/common/CategoryButton/CategoryTypes';
 import {
   LegacyRef,
   PropsWithChildren,
@@ -6,22 +7,29 @@ import {
   useState,
 } from 'react';
 import type { DiaryContent } from '~/types';
+import useDiaryCategories from '../hooks/Diary/useDiaryCategories';
 import useDiaryContext from '../hooks/Diary/useDiaryContext';
+import useSelectSortMethod from '../hooks/Diary/useSelectSortMethod';
 import useDiaryMainObserver from '../hooks/DiaryMain/useDiaryMainObserver';
 import useGetDiarys from '~/services/diary/useGetDiarys';
 
 interface DiaryMainContextProps {
-  selectCategory: string;
-  setSelectCategory: React.Dispatch<React.SetStateAction<string>>;
   recordRef: LegacyRef<HTMLDivElement> | undefined;
   diarys: DiaryContent[];
+  diaryCategory: categoryType | undefined;
+  selectSortMethod: string;
+  handleCategory: (category: categoryType | undefined) => void;
+  handleSortMethodClick: (sortMethod: string) => void;
 }
 
 const DiaryMainContext = createContext<DiaryMainContextProps | null>(null);
 
 const DiaryMainProvider = ({ children }: PropsWithChildren) => {
-  const { diaryCategory, setRootDiarys, selectSortMethod } = useDiaryContext();
-  const [selectCategory, setSelectCategory] = useState('');
+  const [diaryCategory, setDiaryCategory] = useState<categoryType | undefined>(
+    undefined,
+  );
+  const [selectSortMethod, setSelectSortMethod] = useState<string>('datingDay');
+  const { setRootDiarys } = useDiaryContext();
   const [page, setPage] = useState(0);
   const [diarys, setDiarys] = useState<DiaryContent[]>([]);
   const { data: diaryResponse } = useGetDiarys({
@@ -29,7 +37,17 @@ const DiaryMainProvider = ({ children }: PropsWithChildren) => {
     diaryCategory,
     selectSortMethod,
   });
-  const { recordRef } = useDiaryMainObserver({ page, setPage, diarys });
+
+  const { handleCategory } = useDiaryCategories({ setDiaryCategory });
+  const { handleSortMethodClick } = useSelectSortMethod({
+    setSelectSortMethod,
+  });
+  const { recordRef } = useDiaryMainObserver({
+    diaryResponse,
+    page,
+    setPage,
+    diarys,
+  });
 
   useEffect(() => {
     setPage(0);
@@ -41,15 +59,22 @@ const DiaryMainProvider = ({ children }: PropsWithChildren) => {
     } else {
       setDiarys([...diarys, ...diaryResponse.content]);
     }
-  }, [diaryResponse]);
+  }, [page, diaryResponse]);
 
   useEffect(() => {
     setRootDiarys(diarys);
-  }, [diarys]);
+  }, [setRootDiarys, diarys]);
 
   return (
     <DiaryMainContext.Provider
-      value={{ selectCategory, setSelectCategory, recordRef, diarys }}
+      value={{
+        diaryCategory,
+        selectSortMethod,
+        recordRef,
+        diarys,
+        handleCategory,
+        handleSortMethodClick,
+      }}
     >
       {children}
     </DiaryMainContext.Provider>

--- a/src/pages/Diary/contexts/DiaryMainContext.tsx
+++ b/src/pages/Diary/contexts/DiaryMainContext.tsx
@@ -25,11 +25,11 @@ interface DiaryMainContextProps {
 const DiaryMainContext = createContext<DiaryMainContextProps | null>(null);
 
 const DiaryMainProvider = ({ children }: PropsWithChildren) => {
+  const { setRootDiarys } = useDiaryContext();
   const [diaryCategory, setDiaryCategory] = useState<categoryType | undefined>(
     undefined,
   );
   const [selectSortMethod, setSelectSortMethod] = useState<string>('datingDay');
-  const { setRootDiarys } = useDiaryContext();
   const [page, setPage] = useState(0);
   const [diarys, setDiarys] = useState<DiaryContent[]>([]);
   const { data: diaryResponse } = useGetDiarys({

--- a/src/pages/Diary/hooks/Diary/useDiaryCategories.ts
+++ b/src/pages/Diary/hooks/Diary/useDiaryCategories.ts
@@ -1,20 +1,24 @@
+import * as React from 'react';
 import categoryType from '~/components/common/CategoryButton/CategoryTypes';
-import { DiaryContextProps } from '~/pages/Diary/contexts/DiaryContext';
 
 interface useDiaryCategoriesProps {
-  setDiaryCategory: DiaryContextProps['setDiaryCategory'];
+  setDiaryCategory: React.Dispatch<
+    React.SetStateAction<categoryType | undefined>
+  >;
 }
 
 const useDiaryCategories = ({ setDiaryCategory }: useDiaryCategoriesProps) => {
-  const handleCategory = (category: categoryType) => {
-    setDiaryCategory((currCategory) => {
-      currCategory = currCategory === category ? undefined : category;
+  const handleCategory = (category: categoryType | undefined) => {
+    setDiaryCategory((prevCategory) => {
+      if (category === prevCategory) {
+        return undefined;
+      }
 
-      return currCategory;
+      return category;
     });
   };
 
-  return { setDiaryCategory, handleCategory };
+  return { handleCategory };
 };
 
 export default useDiaryCategories;

--- a/src/pages/Diary/hooks/Diary/useMapCategory.ts
+++ b/src/pages/Diary/hooks/Diary/useMapCategory.ts
@@ -145,6 +145,9 @@ const useMapCategory = ({
             categorySearchMode();
             setMarkers([]);
           } else if (status === kakao.maps.services.Status.ERROR) {
+            throw new Error(
+              '일시적인 네트워크 요류예요! 다시 시도해보시겠어요?',
+            );
           }
         },
         { useMapBounds: true, bounds, page },

--- a/src/pages/Diary/hooks/Diary/useSelectSortMethod.ts
+++ b/src/pages/Diary/hooks/Diary/useSelectSortMethod.ts
@@ -1,7 +1,5 @@
-import { DiaryContextProps } from '~/pages/Diary/contexts/DiaryContext';
-
 interface useSelectSortMethodProps {
-  setSelectSortMethod: DiaryContextProps['setSelectSortMethod'];
+  setSelectSortMethod: React.Dispatch<React.SetStateAction<string>>;
 }
 
 const useSelectSortMethod = ({
@@ -11,7 +9,7 @@ const useSelectSortMethod = ({
     setSelectSortMethod(sortMethod);
   };
 
-  return { setSelectSortMethod, handleSortMethodClick };
+  return { handleSortMethodClick };
 };
 
 export default useSelectSortMethod;

--- a/src/pages/Diary/hooks/DiaryContent/useDiaryContent.ts
+++ b/src/pages/Diary/hooks/DiaryContent/useDiaryContent.ts
@@ -121,7 +121,6 @@ const useDiaryContent = ({
     setEditable(true);
   };
 
-  // todo: 빈 문자열이면 오류 띄어야ㅏㅎㅁ
   const handleSubmitCreate = () => {
     const formData = new FormData();
     const { datingDay, category, score, myText } = editDiary;
@@ -136,7 +135,7 @@ const useDiaryContent = ({
       kakaoMapId: Number(kakaoMapId),
       latitude: position.lat,
       longitude: position.lng,
-      address: address,
+      address: address as string,
       datingDay,
       category,
       score,
@@ -163,7 +162,6 @@ const useDiaryContent = ({
       score,
       images: existedImg,
     };
-    console.log(texts);
     formData.append(
       'texts',
       new Blob([JSON.stringify(texts)], { type: 'application/json' }),

--- a/src/pages/Diary/hooks/DiaryContent/useDiaryContent.ts
+++ b/src/pages/Diary/hooks/DiaryContent/useDiaryContent.ts
@@ -135,7 +135,7 @@ const useDiaryContent = ({
       kakaoMapId: Number(kakaoMapId),
       latitude: position.lat,
       longitude: position.lng,
-      address: address as string,
+      address: address,
       datingDay,
       category,
       score,

--- a/src/pages/Diary/hooks/DiaryMain/useDiaryMainObserver.ts
+++ b/src/pages/Diary/hooks/DiaryMain/useDiaryMainObserver.ts
@@ -1,14 +1,16 @@
 import { useRef, useEffect } from 'react';
-import type { DiaryContent } from '~/types';
+import type { DiaryContent, Diarys } from '~/types';
 import useObserve from '~/hooks/useObserve';
 
 interface useDiaryMainObserverProps {
+  diaryResponse: Diarys;
   page: number;
   setPage: React.Dispatch<React.SetStateAction<number>>;
   diarys: DiaryContent[];
 }
 
 const useDiaryMainObserver = ({
+  diaryResponse,
   page,
   setPage,
   diarys,
@@ -19,6 +21,7 @@ const useDiaryMainObserver = ({
   const recordRef = useRef(null);
 
   useEffect(() => {
+    if (diaryResponse.content.length < 10) return;
     if (recordRef && recordRef.current) {
       observe(recordRef.current);
     }

--- a/src/pages/Main/components/MainContent/PreviewDiary.tsx
+++ b/src/pages/Main/components/MainContent/PreviewDiary.tsx
@@ -19,7 +19,12 @@ const PreviewDiary = () => {
     <div className="flex h-full gap-3 overflow-x-auto overflow-y-hidden lg:grid lg:grid-cols-2 lg:overflow-y-auto lg:overflow-x-hidden">
       {recentDiarys.content.map((diary, index) => (
         <div key={`${diary.diaryId}-${index}`}>
-          <Link to={`${paths.DIARY.ROOT}/${diary.kakaoMapId}/${diary.diaryId}`}>
+          <Link
+            to={`${paths.DIARY.ROOT}/${diary.kakaoMapId}/${diary.diaryId}`}
+            state={{
+              diary,
+            }}
+          >
             <DiaryPreviewItem
               date={diary.datingDay}
               location={diary.placeName}

--- a/src/pages/Main/contexts/MainContentContext.tsx
+++ b/src/pages/Main/contexts/MainContentContext.tsx
@@ -7,7 +7,7 @@ import { useCreateTodayQuestion, useGetQuestion } from '~/services/question';
 
 interface MainContentContextProps {
   recentSchedule: CalendarSchedule | undefined;
-  todayQuestion: QuestionForm | undefined;
+  todayQuestion: QuestionFormResponse | undefined;
   recentDiarys: Diarys | undefined;
 }
 

--- a/src/pages/Main/contexts/ProfileContext.tsx
+++ b/src/pages/Main/contexts/ProfileContext.tsx
@@ -60,7 +60,6 @@ const ProfileProvider = ({ children }: PropsWithChildren) => {
 
   const handleOpenProfileModal = useCallback(
     ({ birthday, calendarColor, imageUrl, mbti, nickname, id }: User) => {
-      console.log(birthday, calendarColor, imageUrl, mbti, nickname, id);
       setModalInfo({
         birthday,
         calendarColor,

--- a/src/types/diary.ts
+++ b/src/types/diary.ts
@@ -25,6 +25,8 @@ interface DiaryResponse extends Diary {
   pictures: Pictures;
   myText: string;
   opponentText: string;
+  latitude: number;
+  longitude: number;
 }
 
 interface DiaryCreateTextRequest extends Diary {

--- a/src/types/map.ts
+++ b/src/types/map.ts
@@ -22,7 +22,7 @@ interface MapMarker {
     lng: number;
   };
   content: string;
-  address?: string;
+  address: string;
   spotId: string;
 }
 

--- a/src/types/map.ts
+++ b/src/types/map.ts
@@ -22,8 +22,7 @@ interface MapMarker {
     lng: number;
   };
   content: string;
-  address: string;
-  phone?: string;
+  address?: string;
   spotId: string;
 }
 


### PR DESCRIPTION
# 🔨 개발 사항 | 변경 사항

### 메인 페이지

- 메인 페이지에서 다이어리 프리뷰를 클릭할 때 로직을 변경했어요.
- 상세 사진으로 이동할 때 diary 와 관련된 정보를 `Link` 태그의 `state` 로 넘겨줘요.

### 다이어리 - DiaryContent

- locate.state 값이 있다면 `info` 데이터 값을 업데이트 시켜요.
- locate.state 값이 있다면 `RootDiary` 데이터 값을 업데이트 시켜요.

