### PR TITLE
✨ Feat: 다이어리 마커 즉시 반영 및 쿼리키 무효 적용

### DIFF
--- a/src/pages/Diary/Diary.tsx
+++ b/src/pages/Diary/Diary.tsx
@@ -2,6 +2,7 @@ import { Outlet } from 'react-router-dom';
 import { DiarySideBar } from './components/DiaryCommon';
 import DiaryMap from '~/pages/Diary/components/DiaryMap/DiaryMap';
 import { DiaryProvider } from '~/pages/Diary/contexts/DiaryContext';
+import { DiaryMainProvider } from '~/pages/Diary/contexts/DiaryMainContext';
 import { DiaryMapProvider } from '~/pages/Diary/contexts/DiaryMapContext';
 
 const Diary = () => {
@@ -9,10 +10,12 @@ const Diary = () => {
     <DiaryProvider>
       <div className="h-full w-full">
         <DiaryMapProvider>
-          <DiarySideBar>
-            <Outlet />
-          </DiarySideBar>
-          <DiaryMap />
+          <DiaryMainProvider>
+            <DiarySideBar>
+              <Outlet />
+            </DiarySideBar>
+            <DiaryMap />
+          </DiaryMainProvider>
         </DiaryMapProvider>
       </div>
     </DiaryProvider>

--- a/src/pages/Diary/components/DiaryContent/DiaryContentDetail.tsx
+++ b/src/pages/Diary/components/DiaryContent/DiaryContentDetail.tsx
@@ -7,11 +7,19 @@ const DiaryContentDetail = () => {
   const { myText, opponentText } = diary;
   const { handleChangeMyText } = methods;
 
+  console.log(editable);
+
   return (
     <div className="flex flex-col gap-2">
       <span className="text-lg font-bold text-base-black">다이어리 내용</span>
       <div className="flex flex-col gap-4 py-2">
-        <DiaryContentImgs />
+        {!editable && diary.pictures.firstImage === null ? (
+          <span className="text-center text-sm text-grey-300">
+            함께 찍은 사진들을 공유하세요!
+          </span>
+        ) : (
+          <DiaryContentImgs />
+        )}
         <div>
           <div>
             <div className="text-lg font-bold">나의 기록</div>

--- a/src/pages/Diary/components/DiaryContent/DiaryContentDetail.tsx
+++ b/src/pages/Diary/components/DiaryContent/DiaryContentDetail.tsx
@@ -7,8 +7,6 @@ const DiaryContentDetail = () => {
   const { myText, opponentText } = diary;
   const { handleChangeMyText } = methods;
 
-  console.log(editable);
-
   return (
     <div className="flex flex-col gap-2">
       <span className="text-lg font-bold text-base-black">다이어리 내용</span>

--- a/src/pages/Diary/components/DiaryMain/DiaryRecords.tsx
+++ b/src/pages/Diary/components/DiaryMain/DiaryRecords.tsx
@@ -4,7 +4,6 @@ import DiaryMainLoadingFallback from './DiaryMainLoadingFallback';
 import DiaryRecordsHeader from './DiaryRecordsHeader';
 import DiaryRecordsPreviews from './DiaryRecordsPreviews';
 import CategoryList from '~/components/domain/CategoryList/CategoryList';
-import { DiaryMainProvider } from '~/pages/Diary/contexts/DiaryMainContext';
 
 const DiaryRecords = () => {
   const diaryMainContext = useDiaryMainContext();
@@ -19,9 +18,7 @@ const DiaryRecords = () => {
         selectedCategory={diaryCategory}
       />
       <Suspense fallback={<DiaryMainLoadingFallback />}>
-        {/* <DiaryMainProvider> */}
         <DiaryRecordsPreviews />
-        {/* </DiaryMainProvider> */}
       </Suspense>
     </div>
   );

--- a/src/pages/Diary/components/DiaryMain/DiaryRecords.tsx
+++ b/src/pages/Diary/components/DiaryMain/DiaryRecords.tsx
@@ -19,9 +19,9 @@ const DiaryRecords = () => {
         selectedCategory={diaryCategory}
       />
       <Suspense fallback={<DiaryMainLoadingFallback />}>
-        <DiaryMainProvider>
-          <DiaryRecordsPreviews />
-        </DiaryMainProvider>
+        {/* <DiaryMainProvider> */}
+        <DiaryRecordsPreviews />
+        {/* </DiaryMainProvider> */}
       </Suspense>
     </div>
   );

--- a/src/pages/Diary/components/DiaryMain/DiaryRecordsPreviews.tsx
+++ b/src/pages/Diary/components/DiaryMain/DiaryRecordsPreviews.tsx
@@ -17,9 +17,13 @@ const DiaryRecordsPreviews = () => {
     handleClickPreview(diary);
   };
 
+  const diaryWrapStyle = diarys.length && 'h-full';
+
   return (
     <div className="h-full lg:overflow-hidden">
-      <div className="grid h-full auto-rows-min grid-cols-3 lg:grid-cols-2 lg:overflow-y-auto">
+      <div
+        className={`grid auto-rows-min grid-cols-3 lg:grid-cols-2 lg:overflow-y-auto ${diaryWrapStyle}`}
+      >
         {diarys.map((diary, index) => (
           <div
             key={`${diary.diaryId}-${index}`}

--- a/src/pages/Diary/components/DiaryMain/DiaryRecordsPreviews.tsx
+++ b/src/pages/Diary/components/DiaryMain/DiaryRecordsPreviews.tsx
@@ -19,7 +19,7 @@ const DiaryRecordsPreviews = () => {
 
   return (
     <div className="h-full lg:overflow-hidden">
-      <div className="grid h-full grid-cols-3 lg:grid-cols-2 lg:overflow-y-auto ">
+      <div className="grid h-full auto-rows-min grid-cols-3 lg:grid-cols-2 lg:overflow-y-auto">
         {diarys.map((diary, index) => (
           <div
             key={`${diary.diaryId}-${index}`}

--- a/src/pages/Diary/components/DiaryMain/DiarySearchBar.tsx
+++ b/src/pages/Diary/components/DiaryMain/DiarySearchBar.tsx
@@ -7,7 +7,7 @@ const DiarySearchBar = () => {
     searchKeyword,
     methods: { handleInput },
   } = useDiaryContext();
-  const { handleKeyUp } = handleInput;
+  const { handleKeyUp, setSearchKeyword } = handleInput;
   const inputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
@@ -25,7 +25,10 @@ const DiarySearchBar = () => {
         onKeyUp={handleKeyUp}
         ref={inputRef}
       />
-      <button className="btn join-item border-l-0 border-base-primary bg-base-white hover:border-base-primary hover:bg-base-white">
+      <button
+        className="btn join-item border-l-0 border-base-primary bg-base-white hover:border-base-primary hover:bg-base-white"
+        onClick={() => setSearchKeyword(inputRef.current?.value || '')}
+      >
         <IconSearch className="fill h-[1.25rem] w-[1.25rem] stroke-base-primary" />
       </button>
     </div>

--- a/src/services/diary/useDeleteDiaryDetail.ts
+++ b/src/services/diary/useDeleteDiaryDetail.ts
@@ -1,7 +1,6 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
 import apiClient from '~/api/apiClient';
-import useGetDiarys from '~/services/diary/useGetDiarys';
 
 interface DeleteDiaryDetailParams {
   diaryList: number[];
@@ -27,10 +26,7 @@ const useDeleteDiaryDetail = (kakaoMapId: string | undefined) => {
         queryKey: ['Diarys'],
       });
       await queryClient.invalidateQueries({
-        queryKey: ['DiarySpot'],
-      });
-      await queryClient.invalidateQueries({
-        queryKey: ['DiaryDetail'],
+        queryKey: ['DiarySpot', Number(kakaoMapId)],
       });
       await queryClient.invalidateQueries({
         queryKey: ['temperature'],

--- a/src/services/diary/useDeleteDiaryDetail.ts
+++ b/src/services/diary/useDeleteDiaryDetail.ts
@@ -1,10 +1,7 @@
-import {
-  InvalidateQueryFilters,
-  useMutation,
-  useQueryClient,
-} from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
 import apiClient from '~/api/apiClient';
+import useGetDiarys from '~/services/diary/useGetDiarys';
 
 interface DeleteDiaryDetailParams {
   diaryList: number[];
@@ -26,9 +23,18 @@ const useDeleteDiaryDetail = (kakaoMapId: string | undefined) => {
     mutationFn: ({ diaryList }: DeleteDiaryDetailParams) =>
       deleteDiaryDetail({ diaryList }),
     onSuccess: async () => {
-      await queryClient.invalidateQueries([
-        ['Diarys', 'temperature'],
-      ] as InvalidateQueryFilters);
+      await queryClient.invalidateQueries({
+        queryKey: ['Diarys'],
+      });
+      await queryClient.invalidateQueries({
+        queryKey: ['DiarySpot'],
+      });
+      await queryClient.invalidateQueries({
+        queryKey: ['DiaryDetail'],
+      });
+      await queryClient.invalidateQueries({
+        queryKey: ['temperature'],
+      });
       navigate(`/diary/${kakaoMapId}`);
     },
   });


### PR DESCRIPTION
# 🔨 개발 사항 
* 다이어리 생성시 마커, 데이터 즉시 반영
* 다이어리 삭제시 마커, 데이터 즉시 반영
* 다이어리 메인 그리드 높이 수정


### 개발 사항
- [ ] 다이어리 생성시 마커, 데이터 즉시 반영
- [ ] 다이어리 삭제시 마커, 데이터 즉시 반영
- [ ] 다이어리 메인 그리드 높이 수정
- [ ] 검색 로직 아이콘 클릭시에도 적용
- [ ] 쿼리키 무효화 적용 및 프로바이더 위치 변경


# 📝 리뷰어들이 보면 좋을 사항
`diaryMain` 컴포넌트와 map쪽에서 사용되는 데이터들이 아무래도 공유되는 데이터가 많다보니 프로바이더가 최상위로 올라오게 되었습니다... 우선은 mainProvider를 diary전체를 한 번 감싸주도록 변경했는데 이 부분은 시연 이후 추후 리팩토링때 다시 논의해보죠!

# 🚨 이슈번호
- close #155 