### PR TITLE
🚨 Fix: 다이어리 지도 초기 위치 설정

### DIFF
--- a/src/pages/Diary/components/DiaryMap/DiaryMap.tsx
+++ b/src/pages/Diary/components/DiaryMap/DiaryMap.tsx
@@ -29,8 +29,6 @@ const DiaryMap = () => {
     libraries: ['clusterer', 'drawing', 'services'],
   });
 
-  // if (!userPosition) return;
-
   return (
     <Map
       id="map"

--- a/src/pages/Diary/components/DiaryMap/DiaryMap.tsx
+++ b/src/pages/Diary/components/DiaryMap/DiaryMap.tsx
@@ -29,12 +29,12 @@ const DiaryMap = () => {
     libraries: ['clusterer', 'drawing', 'services'],
   });
 
-  if (!userPosition) return;
+  // if (!userPosition) return;
 
   return (
     <Map
       id="map"
-      center={userPosition || { lat: 33.450701, lng: 126.570667 }}
+      center={userPosition || { lat: 37.5759, lng: 126.9768 }}
       style={{
         width: '100%',
         height: '100%',
@@ -43,8 +43,8 @@ const DiaryMap = () => {
       onCreate={setMap}
       onClick={closeInfo}
     >
-      <DiaryMapMarker userPosition={userPosition} />
-      {infoOpen && info && <DiaryCustomInfo info={info} />}
+      {userPosition && <DiaryMapMarker userPosition={userPosition} />}
+      {infoOpen && info && userPosition && <DiaryCustomInfo info={info} />}
       <DiaryMapButtons />
       <DiaryMapCategories />
     </Map>

--- a/src/pages/Diary/hooks/Diary/useCurrentLocation.ts
+++ b/src/pages/Diary/hooks/Diary/useCurrentLocation.ts
@@ -20,8 +20,8 @@ const useMapLocation = ({ map }: useMapLocationProps) => {
 
     useEffect(() => {
       const options = {
-        enableHighAccuracy: true,
-        timeout: 5000,
+        enableHighAccuracy: false,
+        timeout: Infinity,
         maximumAge: 0,
       };
 


### PR DESCRIPTION
# 🔨 개발 사항 | 변경 사항
다이어리 지도의 초기 위치를 광화문으로 설정해 내 위치를 찾기 전 임시로 보여주도록 했습니다.

# 📝 리뷰어들이 보면 좋을 사항
현재 Develop 브랜치에서도 그런 것 같은데 '메인 홈'에서 '우리의 추억들' 리스트 클릭시 가끔 kakao undefined가 사이드바에 뜨는데, 지금 제 쪽에서 어제 도연님이 말씀해주신 질문쪽 에러가 터져서 에러 로그나 콘솔로 확인해볼 수 가 없는 상태입니다 ㅠㅠ 혹시 어디 쪽에서 에러가 뜨는지 알려주시면 감사하겠습니다!

# 🚨 이슈번호
- close #163 