### PR TITLE
🚨 Fix : 다이어리 목록 클릭 이슈, 페이지 진입시 지도 위치 이슈 해결

### DIFF
--- a/src/pages/Diary/hooks/Diary/useClickPreview.ts
+++ b/src/pages/Diary/hooks/Diary/useClickPreview.ts
@@ -53,6 +53,7 @@ const useClickPreview = () => {
   };
 
   useEffect(() => {
+    console.log(userPosition, info, hasEffectApplied);
     if (userPosition && map && info && !hasEffectApplied) {
       const newLatLng = new kakao.maps.LatLng(
         info.position.lat,
@@ -61,7 +62,7 @@ const useClickPreview = () => {
       map.setCenter(newLatLng);
       setHasEffectApplied(true);
     }
-  }, [info, userPosition, map, hasEffectApplied]);
+  }, [info, map, hasEffectApplied]);
 
   return { handleClickPreview };
 };

--- a/src/pages/Diary/hooks/Diary/useClickPreview.ts
+++ b/src/pages/Diary/hooks/Diary/useClickPreview.ts
@@ -1,5 +1,5 @@
 import { useAtom, useAtomValue, useSetAtom } from 'jotai';
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { paths } from '~/router';
 import { DiaryContent } from '~/types';

--- a/src/pages/Diary/hooks/Diary/useClickPreview.ts
+++ b/src/pages/Diary/hooks/Diary/useClickPreview.ts
@@ -8,6 +8,7 @@ import useInfoToggle from '~/pages/Diary/hooks/Diary/useInfoToggle';
 import useInputRef from '~/pages/Diary/hooks/Diary/useInputRef';
 import useMapCategory from '~/pages/Diary/hooks/Diary/useMapCategory';
 import { infoAtom, mapAtom, markersAtom } from '~/stores/diaryAtoms';
+import { hasEffectAppliedAtom } from '~/stores/diaryMapAtoms';
 
 const useClickPreview = () => {
   const map = useAtomValue(mapAtom);
@@ -20,12 +21,10 @@ const useClickPreview = () => {
   const { useCurrentLocation } = useMapLocation();
   const { userPosition } = useCurrentLocation();
 
-  const [hasEffectApplied, setHasEffectApplied] = useState(false);
+  const [hasEffectApplied, setHasEffectApplied] = useAtom(hasEffectAppliedAtom);
 
   const handleClickPreview = (preview: DiaryContent) => {
     if (!map || !userPosition) return;
-
-    console.log(userPosition);
 
     const info = {
       position: {
@@ -53,16 +52,16 @@ const useClickPreview = () => {
   };
 
   useEffect(() => {
-    console.log(userPosition, info, hasEffectApplied);
     if (userPosition && map && info && !hasEffectApplied) {
       const newLatLng = new kakao.maps.LatLng(
         info.position.lat,
         info.position.lng,
       );
+
       map.setCenter(newLatLng);
       setHasEffectApplied(true);
     }
-  }, [info, map, hasEffectApplied]);
+  }, [info]);
 
   return { handleClickPreview };
 };

--- a/src/pages/Diary/hooks/Diary/useCurrentLocation.ts
+++ b/src/pages/Diary/hooks/Diary/useCurrentLocation.ts
@@ -1,31 +1,38 @@
-import { useAtomValue } from 'jotai';
+import { useAtom, useAtomValue } from 'jotai';
 import { useEffect, useState } from 'react';
-import { Coordinates, Position } from '~/types';
+import { Position } from '~/types';
 import { mapAtom } from '~/stores/diaryAtoms';
+import { hasEffectAppliedAtom, userPositionAtom } from '~/stores/diaryMapAtoms';
 
 const useMapLocation = () => {
   const map = useAtomValue(mapAtom);
+  const [hasEffectApplied, setHasEffectApplied] = useAtom(hasEffectAppliedAtom);
+
   const useCurrentLocation = () => {
-    const [userPosition, setUserPosition] = useState<Coordinates | null>(null);
+    const [userPosition, setUserPosition] = useAtom(userPositionAtom);
     const [isCurrentLocation, setIsCurrentLocation] = useState<boolean>(true);
     const [curMapCenterPosition, setCurMapCenterPosition] =
       useState<kakao.maps.LatLng>();
 
     const onSuccess = (position: Position) => {
       const { latitude, longitude } = position.coords;
-      console.log(latitude, longitude);
+
       setUserPosition({ latitude, longitude });
     };
 
     useEffect(() => {
-      const options = {
-        enableHighAccuracy: false,
-        timeout: Infinity,
-        maximumAge: 0,
-      };
+      if (!hasEffectApplied) {
+        const options = {
+          enableHighAccuracy: false,
+          timeout: Infinity,
+          maximumAge: 0,
+        };
 
-      navigator.geolocation.getCurrentPosition(onSuccess, null, options);
-    }, []);
+        navigator.geolocation.getCurrentPosition(onSuccess, null, options);
+
+        setHasEffectApplied(true);
+      }
+    }, [hasEffectApplied]);
 
     const userPositionLatLng = userPosition && {
       lat: userPosition.latitude,

--- a/src/pages/Diary/hooks/Diary/useCurrentLocation.ts
+++ b/src/pages/Diary/hooks/Diary/useCurrentLocation.ts
@@ -13,6 +13,7 @@ const useMapLocation = () => {
 
     const onSuccess = (position: Position) => {
       const { latitude, longitude } = position.coords;
+      console.log(latitude, longitude);
       setUserPosition({ latitude, longitude });
     };
 

--- a/src/stores/diaryAtoms.ts
+++ b/src/stores/diaryAtoms.ts
@@ -1,5 +1,5 @@
 import { atom } from 'jotai';
-import { DiaryContent, MapMarker } from '~/types';
+import { Coordinates, DiaryContent, MapMarker } from '~/types';
 import categoryType from '~/components/common/CategoryButton/CategoryTypes';
 
 export const searchKeywordAtom = atom('');
@@ -12,3 +12,4 @@ export const infoOpenAtom = atom<boolean>(false);
 export const mapAtom = atom<kakao.maps.Map | undefined>(undefined);
 export const mapCategoryAtom = atom<categoryType | undefined>(undefined);
 export const rootDiarysAtom = atom<DiaryContent[]>([]);
+export const userPositionAtom = atom<Coordinates | null>(null);

--- a/src/stores/diaryAtoms.ts
+++ b/src/stores/diaryAtoms.ts
@@ -1,5 +1,5 @@
 import { atom } from 'jotai';
-import { Coordinates, DiaryContent, MapMarker } from '~/types';
+import { DiaryContent, MapMarker } from '~/types';
 import categoryType from '~/components/common/CategoryButton/CategoryTypes';
 
 export const searchKeywordAtom = atom('');
@@ -12,4 +12,3 @@ export const infoOpenAtom = atom<boolean>(false);
 export const mapAtom = atom<kakao.maps.Map | undefined>(undefined);
 export const mapCategoryAtom = atom<categoryType | undefined>(undefined);
 export const rootDiarysAtom = atom<DiaryContent[]>([]);
-export const userPositionAtom = atom<Coordinates | null>(null);

--- a/src/stores/diaryMapAtoms.ts
+++ b/src/stores/diaryMapAtoms.ts
@@ -1,5 +1,5 @@
 import { atom } from 'jotai';
-import { MapMarker } from '~/types';
+import { Coordinates, MapMarker } from '~/types';
 
 export type MapCategory =
   | 'CAFE'
@@ -12,3 +12,5 @@ export type MarkerFilter = 'ALL' | 'GONE' | 'YET' | '';
 export const markerFilterAtom = atom<MarkerFilter>('ALL');
 export const goneMarkersAtom = atom<MapMarker[]>([]);
 export const yetMarkersAtom = atom<MapMarker[]>([]);
+export const userPositionAtom = atom<Coordinates | null>(null);
+export const hasEffectAppliedAtom = atom<boolean>(false);


### PR DESCRIPTION
# 🔨 개발 사항 | 변경 사항
* 다이어리 페이지의 사이드바에서 다이어리 목록들을 클릭시 즉시 해당 위도, 경도로 이동하지 않는 에러를 해결했습니다.
* 다른 페이지 (캘린더, 질문) 에서 다이어리 페이지 진입 시 마지막 info의 위치에 머물러있는 에러를 해결했습니다. (현재 내 위치로 이동)

### 개발 사항
- [x] 사이드바에서 다이어리 목록 클릭 시 diaryDetail로 즉시 이동
- [x] 다이어리 페이지 진입 시 항상 현재 내 위치로 이동하도록 수정


# 📝 리뷰어들이 보면 좋을 사항

현재 테스트해보니 Jotai로 관리하고 있는 값들 (info, category, marker, search 여부... 등등)이 다른 페이지에서 다이어리 페이지로 재진입시 마지막 값을 그대로 유지하고 있습니다. (예를 들어, 다이어리 페이지에서 지도의 카테고리를 클릭하면 검색 모드가 true로 바뀌고 해당 검색 내용을 토대로 마커가 찍히는데, 페이지를 변경하고 와도 이 값들이 유지되고 있습니다.) 

이 부분을 전체적으로 한 번 초기화하는 작업이 필요할 것 같아서 이 부분은 따로 작업하도록 하겠습니다.

# 🚨 이슈번호
- close #186 
- close #188 
